### PR TITLE
Maude v0.1.7 — save/rest/recall drive off the house-map

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 6.0.0
+> **Version:** 0.1.7
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
-<!-- Version: 2.0 -->
-<!-- Revised: 2026-05-04 MST — plugin-only -->
+<!-- Version: 0.1.7 -->
+<!-- Revised: 2026-05-24 MST — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Bug Report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
-<!-- Version: 2.0 -->
-<!-- Revised: 2026-05-04 MST — plugin-only -->
+<!-- Version: 0.1.7 -->
+<!-- Revised: 2026-05-24 MST — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Feature Request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-<!-- Version: 3.0 -->
-<!-- Revised: 2026-05-08 MST — scrub removed; tests + verify are the local gates -->
+<!-- Version: 0.1.7 -->
+<!-- Revised: 2026-05-24 MST — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 ## What does this PR do?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # Maude for Claude — CI
 # Copyright (c) 2026 John Broadway
 # Licensed under the Apache License, Version 2.0
-# Version: 5.0
-# Revised: 2026-05-08 MST — origin-scrub job removed; tests + verify only
+# Version: 0.1.7
+# Revised: 2026-05-24 MST — version-header sweep; tests + verify only
 # Authors: John Broadway, Claude (Anthropic)
 #
 # Two independent jobs run on every push and pull request to main:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The house-map already *registered* every memory source, but the commands didn't 
 - **Read commands enumerate from the map too.** `wake` / `brief` / `remind-me` recall from every source the map lists per its `recall:` method and the read-side tier gate, instead of hard-coding `$REMEMBER` / `$MEM` paths; `where-is` now resolves the map via `$CLAUDE_PROJECT_DIR` (was `pwd`, wrong from a subdir).
 - **`found.md` stamps a token per source** on the walk, so future maps are loop-ready.
 - **Fallback contract.** When the map is absent or a universal source isn't listed, the documented defaults fire (Anthropic memory → `digest-fanout`, `.remember/remember.md` → `handoff-only`) — so a fresh project still saves, but an edited map is never overridden by hard-code.
-- **Version-header drift corrected.** `.claude/CLAUDE.md`, `README.md`, `CHANGELOG.md`, `skills/README.md`, and the `.github/` templates + `SECURITY.md` carried stale standalone `Version:` headers (6.0.0 / 6.0 / 5.0 / 3.0 / 2.0) that didn't track the plugin. All aligned to the real line (`0.1.7`); their stale `Revised:` dates refreshed so the `verify` date-staleness gate passes.
+- **Version-header drift corrected.** Every standalone `Version:` header in the repo that had drifted to a fictional number not tracking the plugin — across the docs (`.claude/CLAUDE.md`, `README.md`, `CHANGELOG.md`, `skills/README.md`), the `.github/` templates, `SECURITY.md`, `CODE_OF_CONDUCT.md`, and the CI workflow — was aligned to the real line (`0.1.7`). Stale `Revised:` dates on the affected `.md` files were refreshed so the `verify` date-staleness gate passes.
 
 ### Behavior notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,31 @@
-<!-- Version: 5.0 -->
+<!-- Version: 0.1.7 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-05-08 MST -->
+<!-- Revised: 2026-05-24 MST -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.1.7 — save/rest/recall drive off the house-map (2026-05-24)
+
+The house-map already *registered* every memory source, but the commands didn't *obey* it — `save`/`rest` hard-coded the two common stores (Anthropic auto-memory + `.remember/`) by directory check, so an edit to the map's `write:` rule for those sources was silently ignored. This wires the map as the single source of truth, so "she works with whatever's there" is enforced by the mechanism, not just stated in `identity.md`.
+
+### What changed
+
+- **`write:` is now an authoritative token field.** The house-map's `## Memory sources` entries lead each `write:` with one enumerated token — `digest-fanout`, `handoff-only`, `full`, `read-only`, `secret-deny` — with optional prose after. `save`/`rest` execute the token deterministically (no parse-the-prose-and-hope). Unrecognized tokens fail safe (skip) and fail loud (named in the report). Documented in `skills/maude/SKILL.md` ("The `write:` field is authoritative").
+- **`save.md` / `rest.md` drive off the map.** Hard-coded per-source write steps replaced by a single loop: for each registered source, apply the tier gate, then the `write:` token. Editing the map now changes behavior. Report names each destination and the token it obeyed.
+- **Read commands enumerate from the map too.** `wake` / `brief` / `remind-me` recall from every source the map lists per its `recall:` method and the read-side tier gate, instead of hard-coding `$REMEMBER` / `$MEM` paths; `where-is` now resolves the map via `$CLAUDE_PROJECT_DIR` (was `pwd`, wrong from a subdir).
+- **`found.md` stamps a token per source** on the walk, so future maps are loop-ready.
+- **Fallback contract.** When the map is absent or a universal source isn't listed, the documented defaults fire (Anthropic memory → `digest-fanout`, `.remember/remember.md` → `handoff-only`) — so a fresh project still saves, but an edited map is never overridden by hard-code.
+- **Version-header drift corrected.** `.claude/CLAUDE.md`, `README.md`, `CHANGELOG.md`, and `skills/README.md` carried stale standalone `Version:` headers (6.0.0 / 6.0 / 5.0 / 2.0) that didn't track the plugin. Aligned to the real line (`0.1.7`).
+
+### Behavior notes
+
+- The "never touch a sibling system's pipeline files" rule is unchanged — it's now expressed as the `handoff-only` token (writes only the one handoff file) rather than a hard-coded special case for `.remember/`.
+- `secret-deny` sources are never written and never echoed; read commands skip "explicit ask" sources during routine recall.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The house-map already *registered* every memory source, but the commands didn't 
 - **Read commands enumerate from the map too.** `wake` / `brief` / `remind-me` recall from every source the map lists per its `recall:` method and the read-side tier gate, instead of hard-coding `$REMEMBER` / `$MEM` paths; `where-is` now resolves the map via `$CLAUDE_PROJECT_DIR` (was `pwd`, wrong from a subdir).
 - **`found.md` stamps a token per source** on the walk, so future maps are loop-ready.
 - **Fallback contract.** When the map is absent or a universal source isn't listed, the documented defaults fire (Anthropic memory → `digest-fanout`, `.remember/remember.md` → `handoff-only`) — so a fresh project still saves, but an edited map is never overridden by hard-code.
-- **Version-header drift corrected.** `.claude/CLAUDE.md`, `README.md`, `CHANGELOG.md`, and `skills/README.md` carried stale standalone `Version:` headers (6.0.0 / 6.0 / 5.0 / 2.0) that didn't track the plugin. Aligned to the real line (`0.1.7`).
+- **Version-header drift corrected.** `.claude/CLAUDE.md`, `README.md`, `CHANGELOG.md`, `skills/README.md`, and the `.github/` templates + `SECURITY.md` carried stale standalone `Version:` headers (6.0.0 / 6.0 / 5.0 / 3.0 / 2.0) that didn't track the plugin. All aligned to the real line (`0.1.7`); their stale `Revised:` dates refreshed so the `verify` date-staleness gate passes.
 
 ### Behavior notes
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,6 @@
-<!-- Version: 1.0 -->
+<!-- Version: 0.1.7 -->
 <!-- Created: 2026-03-28 MST -->
+<!-- Revised: 2026-05-24 MST — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Code of Conduct

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- Version: 6.0 -->
+<!-- Version: 0.1.7 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-05-08 MST -->
+<!-- Revised: 2026-05-24 MST -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 <div align="center">
@@ -79,6 +79,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.1.7 (2026-05-24) — save/rest/recall drive off the house-map.** The house-map registered every memory source, but `save`/`rest` hard-coded the two common stores by directory check — so editing the map's `write:` rule for them did nothing. Now `write:` is an authoritative token (`digest-fanout` / `handoff-only` / `full` / `read-only` / `secret-deny`) that `save`/`rest` execute deterministically, and the read commands (`wake` / `brief` / `remind-me`) recall from whatever the map lists. Edit the map, change the behavior — "she works with whatever's there" is now wired, not just stated. Universal stores remain a fallback only when the map is silent. Stale standalone `Version:` headers across the docs corrected to the real `0.1.7` line.
 
 **v0.1.6 (2026-05-08) — gate hardening + full hook test coverage.** The v0.1.5 gate matched bare substrings, so a HEREDOC commit message containing the literal "git push" self-blocked the commit that shipped it. v0.1.6 introduces `maude_strip_quotes` and `maude_match_gate_pattern` in `_maude-common.sh`: paired single- and double-quoted spans (and the heredoc bodies that nest inside `"$(cat <<EOF ... EOF)"`) are stripped before pattern-matching, and every gate pattern carries its own command-position or flag-position anchor. Side effect: `rm -rf /tmp/foo` and `rm -rf *.tmp` no longer false-positive. Plus a real test harness — `tests/lib.sh` + 16 `tests/test-*.sh` + `make test` — exercising every script in `hooks/scripts/` and `scripts/maude-verify.sh`. From 9 ad-hoc invocations in v0.1.5 to 162 codified test cases.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
-<!-- Version: 2.0 -->
-<!-- Revised: 2026-05-04 MST — plugin-only -->
+<!-- Version: 0.1.7 -->
+<!-- Revised: 2026-05-24 MST — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Security Policy

--- a/commands/brief.md
+++ b/commands/brief.md
@@ -30,40 +30,27 @@ MAP="$SELF/house-map.md"
 1. **House-map** — read it first. It tells you where everything is for this project.
    - If missing, suggest `/maude:found` and proceed with the always-available sources as fallback.
 
-2. **Anthropic auto-memory** (if `[ -d "$MEM" ]`):
-   - `cat "$MEM/now.md"` — live buffer
-   - `ls "$MEM"/today-*.md 2>/dev/null | tail -1 | xargs cat` — most recent daily
-   - `cat "$MEM/recent.md"` — 7-day rolling
-   - `cat "$MEM/MEMORY.md"` — index (note "Next" / "State" sections)
-   - `cat "$MEM/letter-to-next-claude.md" 2>/dev/null` — relational handoff if present
+2. **Recall from every source the map lists** (`## Memory sources`) — don't hard-code paths.
+   For each entry, apply the read-side tier gate (Tier 0 always; Tier 1 only if `tier1_up`
+   cached; Tier 2 never on brief), then recall per its `recall:` method at its `path:`. Reads
+   honor `recall:`, not the write token — so read a `handoff-only` source's pipeline files
+   (`now.md`, latest `today-*.md`, `recent.md`, `archive.md`, `core-memories.md`,
+   `remember.md`) freely for context; read Anthropic auto-memory's `now.md` / latest daily /
+   `recent.md` / `MEMORY.md` / any `letter-to-next-claude.md`; read her cross-project
+   `patterns.md` / `identity.md` / `projects.json`. **Skip any source whose `recall:` says
+   "explicit ask" (`secret-deny` vaults) and never echo secrets.** All reads are read-only —
+   a brief never writes.
+   - Also read the non-memory locations the map records: project-root `MEMORY.md`,
+     `journal/$(date +%Y-%m).md`, newest `decisions/` entries, any registered vault per its
+     recorded recall protocol.
+   - **Fallback if the map is silent:** read the universal sources directly — `$MEM`,
+     `.remember/`, `$USER_DIR` — as before.
 
-3. **remember plugin's `.remember/`** (if `[ -d "$REMEMBER" ]`) — read all of these as additional context:
-   - `cat "$REMEMBER/now.md"` — remember's live buffer (its pipeline maintains this)
-   - `ls "$REMEMBER"/today-*.md 2>/dev/null | tail -1 | xargs cat` — most recent daily summary
-   - `cat "$REMEMBER/recent.md"` — last 7 days consolidated
-   - `cat "$REMEMBER/archive.md" 2>/dev/null` — older history
-   - `cat "$REMEMBER/core-memories.md" 2>/dev/null` — key moments
-   - `cat "$REMEMBER/remember.md" 2>/dev/null` — agent-handoff if last session left one
+3. **Query SQLite databases** registered under `## Databases found` — only if `status: usable` AND the user has provided a recall recipe (or you can reason one from the schema). For a brief, prefer time-ordered queries: schema-walk for any timestamp-like column (`updated_at`, `modified`, `ts`, `created_at`, etc.), then `ORDER BY <that-col> DESC LIMIT 10`. Always `sqlite3 -readonly`. Skip dbs without a recipe and marked `needs-user-clarification`.
 
-   These are READ-ONLY for Maude. Don't write to any of them except `remember.md` (only on `/maude:save`, in remember's handoff format).
+4. **Filter** to `${ARGUMENTS}` if provided — grep for the term across everything you read.
 
-4. **Cross-project context** from her own home base (if `[ -d "$USER_DIR" ]`):
-   - `cat "$USER_DIR/patterns.md" 2>/dev/null` — cross-project patterns she's noticed
-   - `cat "$USER_DIR/identity.md" 2>/dev/null` — what she knows about the user
-   - check `"$USER_DIR/projects.json"` for prior visits to this project
-
-5. **For each additional location in the house-map's "Memory locations found"**, read its equivalent files:
-   - `MEMORY.md` at project root
-   - `journal/$(date +%Y-%m).md` if user keeps one
-   - `decisions/` newest entries
-   - registered framework-side memory dirs (per the house-map)
-   - Vaults: any user-maintained memory dirs (per the protocol recorded in the house-map)
-
-6. **Query SQLite databases** registered under `## Databases found` — only if `status: usable` AND the user has provided a recall recipe (or you can reason one from the schema). For a brief, prefer time-ordered queries: schema-walk for any timestamp-like column (`updated_at`, `modified`, `ts`, `created_at`, etc.), then `ORDER BY <that-col> DESC LIMIT 10`. Always `sqlite3 -readonly`. Skip dbs without a recipe and marked `needs-user-clarification`.
-
-6. **Filter** to `${ARGUMENTS}` if provided — grep for the term across everything you read.
-
-7. **Compose** a digest:
+5. **Compose** a digest:
 
 ```
 Maude here. Last session: <one-line from now.md>

--- a/commands/found.md
+++ b/commands/found.md
@@ -173,6 +173,15 @@ You are Maude. You just moved in. Walk the house and take inventory. **List what
 
 5. **Compose the house-map** following the template in `skills/maude/SKILL.md`. Write to `$MAP`. If `${ARGUMENTS}` is `--refresh` or `$MAP` already exists, overwrite (re-walk). Otherwise, only write if missing — preserve existing user notes by reading the existing map first and merging the `Notes` section forward.
 
+   **For every `## Memory sources` entry, set `write:` to one enumerated token** (so save/rest
+   can drive off it — see SKILL.md "The `write:` field is authoritative"): `digest-fanout`
+   (Claude-continuity stores like Anthropic auto-memory), `handoff-only` (a sibling system's
+   single agent-handoff file, e.g. remember's `remember.md` — never its pipeline files),
+   `full` (Maude's own stores), `read-only` (recall-only dirs), `secret-deny` (credential
+   vaults — also record these under `## Vaults`). Lead with the token; free prose may follow.
+   When unsure, default an external store to `read-only` and flag it for the user to confirm
+   the write protocol.
+
 6. **Report what's organized AND propose:**
 
    ```

--- a/commands/remind-me.md
+++ b/commands/remind-me.md
@@ -31,40 +31,31 @@ MAP="$SELF/house-map.md"
 
 1. **Read the house-map** — it lists every memory location for this project.
 
-2. **Search Anthropic auto-memory** (if `[ -d "$MEM" ]`):
+2. **Search every source the map lists** (`## Memory sources`) — don't hard-code paths. For
+   each entry, apply the tier gate (Tier 0 always; Tier 1 if `tier1_up` cached; Tier 2 only
+   on `--deep` or a rich-query tag), then grep its `path:` per its `recall:` method. Reads
+   honor `recall:` — search a `handoff-only` source's whole dir (its compressed pipeline
+   often has the answer in fewer files), Anthropic auto-memory, and her cross-project home.
+   **Skip `secret-deny` / "explicit ask" sources unless the topic explicitly targets them,
+   and never echo secrets.**
    ```bash
-   grep -rln -i "$ARGUMENTS" "$MEM" 2>/dev/null
+   # for each source PATH from the map:
+   grep -rln -i "$ARGUMENTS" "$SRC_PATH" 2>/dev/null
    ```
+   **Fallback if the map is silent:** grep `$MEM`, `$REMEMBER`, `$USER_DIR` directly.
 
-3. **Search remember's `.remember/`** (if `[ -d "$REMEMBER" ]`) — its tier-compressed memory often has the answer in fewer files:
-   ```bash
-   grep -ln -i "$ARGUMENTS" "$REMEMBER"/now.md "$REMEMBER"/today-*.md \
-                            "$REMEMBER"/recent.md "$REMEMBER"/archive.md \
-                            "$REMEMBER"/core-memories.md "$REMEMBER"/remember.md 2>/dev/null
-   ```
+3. **Search additional vaults** the house-map registers (custom journals, decisions). For each: grep its files OR call its recall API per the protocol recorded in the map.
 
-4. **Search her cross-project home** (if `[ -d "$USER_DIR" ]`):
-   ```bash
-   grep -ln -i "$ARGUMENTS" "$USER_DIR"/patterns.md "$USER_DIR"/identity.md 2>/dev/null
-   ```
-
-5. **Search additional vaults** the house-map registers (custom journals, decisions). For each: grep its files OR call its recall API per the protocol recorded in the map.
-
-6. **Query SQLite databases** the house-map registered under `## Databases found` — only if `status: usable` AND the user has confirmed the schema (or the recall recipe field is filled in).
+4. **Query SQLite databases** the house-map registered under `## Databases found` — only if `status: usable` AND the user has confirmed the schema (or the recall recipe field is filled in).
    - For each db, check the registered recall recipe in the map. If it's filled in (e.g., the user added `recall: SELECT body FROM <table> WHERE body LIKE :q`), use it.
    - If the recipe is missing but the db is registered as usable, schema-walk again (`sqlite3 -readonly "$DB" '.schema'`), reason about which columns are likely text-bearing (column names suggesting prose: `body`, `content`, `text`, `description`, `note`, `message`, etc.), and run a `LIKE '%<topic>%'` query on those.
    - Always `sqlite3 -readonly`. Always sanitize `$ARGUMENTS` for single quotes. Skip dbs marked `needs-user-clarification` or `ignored`.
 
    The plugin doesn't ship hardcoded schema recipes. It ships the technique: schema-walk, reason about column purpose, query text-like columns. You — at runtime — are the reasoner.
 
-6. **Read the matching files** — they have the why baked in. Anthropic auto-memory format always includes a `**Why:**` line for feedback/project memories.
+5. **Read the matching files** — they have the why baked in. Anthropic auto-memory format always includes a `**Why:**` line for feedback/project memories.
 
-7. **Recent-session scan** within Anthropic memory:
-   ```bash
-   grep -ln -i "$ARGUMENTS" "$MEM"/now.md "$MEM"/today-*.md "$MEM"/recent.md 2>/dev/null
-   ```
-
-8. **Compose a digest:**
+6. **Compose a digest:**
 
 ```
 You asked about: <topic>

--- a/commands/rest.md
+++ b/commands/rest.md
@@ -25,6 +25,7 @@ MEM="$HOME/.claude/projects/$SLUG/memory"
 SELF="$PROJ/.maude/plugin"
 USER_DIR="$HOME/.claude/maude"
 REMEMBER="$PROJ/.remember"
+MAP="$SELF/house-map.md"
 ```
 
 1. **Compose a digest** of this session:
@@ -33,18 +34,22 @@ REMEMBER="$PROJ/.remember"
    - What's still open?
    - Any half-finished work?
 
-2. **Run the full save flow** (same logic as `/maude:save`):
-   - Anthropic auto-memory: `$MEM/now.md`, `$MEM/today-$(date +%Y-%m-%d).md`, `$MEM/recent.md` (if `$MEM` exists)
-   - **remember.md handoff** (if `[ -d "$REMEMBER" ]`): write the digest to `$REMEMBER/remember.md` in remember's handoff format (`## State` / `## Next` / `## Context`, ≤20 lines)
-   - Other house-map destinations (journal, decisions, vaults)
-   - Cross-project state (`$USER_DIR/patterns.md`, `$USER_DIR/projects.json`)
+2. **Run the map-driven save loop** — identical to `/maude:save` step 3: read `$MAP` and
+   write the digest to **each** `## Memory sources` entry per its tier gate × `write:` token
+   (`digest-fanout`, `handoff-only`, `full`; skip `read-only` / `secret-deny`), honoring any
+   journal/decisions/vault destinations the map records. Same fallback as save step 4 if the
+   map is silent. Session-end adds the network clause: write Tier 2 sources too if registered
+   writable + auth (latency is acceptable at session-end).
 
 3. **Close-the-loop check** — for each watched-list entry touched this session:
    - Is the file in a clean state? (no lingering TODO, no half-removed code)
    - Was there an associated decision worth logging?
    - If something half-done, surface it: "you started X but didn't finish Y."
 
-4. **Tomorrow's starting point.** Write a one-line "what to come back to" — in `$MEM/now.md` AND in `$REMEMBER/remember.md`'s `## Next` section:
+4. **Tomorrow's starting point.** Write a one-line "what to come back to" into the sources
+   the map says carry it — the `digest-fanout` source's live buffer (`now.md`) and the
+   `handoff-only` source's `## Next` section. Don't hard-code paths; use whichever sources
+   hold those tokens.
    ```
    ## Tomorrow
    - <one concrete next action, ≤1 line>

--- a/commands/save.md
+++ b/commands/save.md
@@ -42,53 +42,66 @@ Report per-tier success/fail in the output.
    TIME="$(date +%H:%M)"
    ```
 
-3. **Write to Anthropic auto-memory** (if `[ -d "$MEM" ]`):
-   - Overwrite `$MEM/now.md` with the digest (live buffer).
-   - Append a `## $TIME | <topic>` section + 1-line summary to `$MEM/today-$TODAY.md`.
-   - Append a one-line entry to `$MEM/recent.md`.
+3. **Read the house-map and write per its `## Memory sources` registry.** The map governs
+   where the digest goes — don't hard-code destinations. Read `$MAP`, then for **each**
+   memory source entry: apply the **tier gate** (Tier 0 always; Tier 1 only if `tier1_up`
+   cached; Tier 2 only if registered writable + auth env set), then execute its leading
+   `write:` **token**:
 
-4. **If the remember plugin is installed** (`[ -d "$REMEMBER" ]`), write to **`$REMEMBER/remember.md`** ONLY — that is the agent-handoff file remember explicitly leaves for agents to write. Format (per remember's own SKILL.md):
-   ```
-   # Handoff
+   - **`digest-fanout`** — overwrite the source's live buffer (`now.md`) with the digest;
+     append a `## $TIME | <topic>` block + 1-line summary to its `today-$TODAY.md`; append
+     one line to its `recent.md`. (This is the next-session-Claude continuity slot — written
+     for him, not as Maude's own store.)
+   - **`handoff-only`** — overwrite ONLY the source's single handoff file (e.g.
+     `remember.md`) in the handoff format below. **Never** touch any other file in that dir
+     (`now.md`, `today-*.md`, `recent.md`, `archive.md`, `core-memories.md`, `logs/`,
+     `tmp/`) — that's the owning system's pipeline.
+     ```
+     # Handoff
 
-   ## State
-   {What's done, what's not. Files, MRs, decisions. 2-4 lines max.}
+     ## State
+     {What's done, what's not. Files, MRs, decisions. 2-4 lines max.}
 
-   ## Next
-   {What to pick up. Priority order. 1-3 items.}
+     ## Next
+     {What to pick up. Priority order. 1-3 items.}
 
-   ## Context
-   {Non-obvious gotchas, blockers, preferences from this session. Skip if nothing.}
-   ```
-   - Overwrite `$REMEMBER/remember.md` (it's the live handoff slot).
-   - Under 20 lines total. Specific. Forward-looking.
-   - DO NOT write to `$REMEMBER/now.md`, `today-*.md`, `recent.md`, `archive.md`, or `core-memories.md` — those are remember's pipeline output. Maude reads them; she doesn't touch them.
+     ## Context
+     {Non-obvious gotchas, blockers, preferences from this session. Skip if nothing.}
+     ```
+     Under 20 lines. Specific. Forward-looking.
+   - **`full`** — Maude's own store; write the slice appropriate to this source. For
+     `user-global` (`~/.claude/maude/`): append to `patterns.md` if a cross-project pattern
+     surfaced, and update `projects.json` with this project's slug + last-seen timestamp.
+     For `maude-self` (`.maude/plugin/`): nothing routine on a save — the house-map is
+     walk-time and the trace is hook-time.
+   - **`read-only`** — skip (recall source; never written by save).
+   - **`secret-deny`** — skip and never echo contents.
+   - **unrecognized/malformed token** — skip the source and name it in the report as a
+     warning. Never guess an action from an unknown token: fail safe (no write), fail loud.
 
-5. **Read the house-map** for additional destinations the user maintains. For each one in the "watch list" or notes, append the appropriate slice:
-   - `journal/$TODAY.md` if a `journal/` dir exists
-   - `decisions/<short-title>.md` if a meaningful decision was made and the user keeps a decisions log
-   - Any vault-shaped destination registered in the house-map — write per the protocol the user (or your prior runtime reasoning) recorded there
-   - Any other location the map flags as a writable destination
+   Also honor any non-memory writable destination the map records (journal/, decisions/,
+   user vaults) per the protocol written beside it.
 
-6. **Update her own cross-project state** (`[ -d "$USER_DIR" ]`):
-   - If a meaningful pattern surfaced this session, append a note to `$USER_DIR/patterns.md`.
-   - Update `$USER_DIR/projects.json` with this project's slug + last-seen timestamp.
+4. **Fallback when the map is silent.** Defaults fire ONLY when the map is absent OR a
+   universal source isn't listed — never to override an entry that IS on the map:
+   - Anthropic auto-memory (`$MEM`) if `[ -d "$MEM" ]` and not on the map → `digest-fanout`.
+   - `$REMEMBER/remember.md` if `[ -d "$REMEMBER" ]` and not on the map → `handoff-only`.
 
-7. **Curate as you save.** Before reporting, look at what you just wrote and what's in the broader memory dirs:
+5. **Curate as you save.** Before reporting, look at what you just wrote and what's in the broader memory dirs:
    - Has this topic appeared in N+ today-*.md or recent.md entries this week? If so, propose: "this is the Nth note about <topic> — promote to a reference file at <path>?"
    - Did the digest mention something that's already in a feedback or project memory file? Cross-reference and surface ("this updates feedback_X — want me to revise that file too?")
    - Does the digest contain something that should be on the watch list? ("you mentioned editing CLAUDE.md three times this week — add it to watch list permanently?")
 
-8. **Report what got persisted AND what's worth promoting:**
+6. **Report what got persisted AND what's worth promoting.** Name each destination AND the
+   `write:` token it obeyed, so it's visible the map drove the write (not hard-code):
 
 ```
-Saved.
-  Anthropic memory: ✓ now.md, today-$TODAY.md, recent.md (or — not present)
-  remember plugin: ✓ remember.md handoff written (or — not installed)
-  journal/$TODAY.md: ✓ (or — not present)
-  decisions/: ✓ added '<title>' (or — no decision this session)
-  <vault from house-map>: ✓ / —
-  cross-project: ✓ patterns updated, projects index touched
+Saved (per house-map).
+  anthropic-auto-memory: ✓ digest-fanout — now.md, today-$TODAY.md, recent.md (or — not on map / not present)
+  remember-plugin:       ✓ handoff-only — remember.md (or — not on map / not installed)
+  user-global:           ✓ full — projects index touched (+ patterns.md if a pattern surfaced)
+  <journal/decisions/vault from map>: ✓ <token> / —
+  fallback used:         <none | anthropic-auto-memory | remember-plugin> (only if map was silent)
 
 I noticed:
   - <topic> has come up 3 times this week — promote to reference file?
@@ -100,7 +113,10 @@ Don't just persist. Curate. Offer.
 
 ## If the house-map is missing
 
-Save to Anthropic memory + remember.md (if remember is installed) + her cross-project home. Suggest `/maude:found` so future saves can spread to other locations the user keeps.
+Use the step-4 fallback: `digest-fanout` to Anthropic memory (if present) + `handoff-only`
+to `.remember/remember.md` (if installed). Her own home (`$USER_DIR` — `full`) is always
+hers to write regardless of the map, so still touch `projects.json`. Suggest `/maude:found`
+so future saves spread to every location the user keeps.
 
 ## Voice
 

--- a/commands/wake.md
+++ b/commands/wake.md
@@ -27,19 +27,22 @@ MAP="$SELF/house-map.md"
 ```
 
 1. **House-map check.** Look at `$MAP`. If missing or > 7 days stale, suggest `/maude:found` first; otherwise read it.
-2. **`.remember/` first** if installed (`[ -d "$REMEMBER" ]`) — remember's pipeline already compresses recent context for you:
-   - `cat "$REMEMBER/remember.md"` — last session's handoff (what to come back to)
-   - `cat "$REMEMBER/now.md"` — live buffer
-   - latest `today-*.md`, then `recent.md`
-3. **Anthropic auto-memory** (if `[ -d "$MEM" ]`):
-   - `now.md` (live buffer), latest `today-*.md`, `recent.md`
-   - `letter-to-next-claude.md` if present
-4. **Cross-project context** (if `[ -d "$USER_DIR" ]`):
-   - check `patterns.md` for things she's noticed across projects
-5. **Trace check** (if `[ -d "$SELF/trace" ]`):
+2. **Recall from every source the map lists** (`## Memory sources`). Don't hard-code paths —
+   read what's registered. For each entry, apply the **read-side tier gate** (Tier 0 always;
+   Tier 1 only if marked always-on AND `tier1_up` cached; Tier 2 never on wake), then recall
+   per its `recall:` method at its `path:`. Reads honor `recall:`, not the write token — so
+   read a `handoff-only` source's pipeline files freely for context, but **skip any source
+   whose `recall:` says "explicit ask" (e.g. `secret-deny` vaults) and never echo secrets.**
+   - Prefer the compressed sources first if present — a remember-style pipeline's
+     `remember.md` (last handoff) + `now.md` + latest `today-*.md` + `recent.md` already
+     summarize recent context; Anthropic auto-memory's `now.md` / latest daily / `recent.md`
+     and any `letter-to-next-claude.md`; her cross-project `patterns.md`.
+   - **Fallback if the map is silent:** read the universal sources directly — `.remember/`
+     (if present), `$MEM` (if present), `$USER_DIR/patterns.md`.
+3. **Trace check** (if `[ -d "$SELF/trace" ]`):
    - tail the most recent JSONL — what was Claude doing last
    - Surface any repeated tool calls or stuck patterns
-6. **Surface 1-3 things first.** Pick what matters most: an unresolved blocker, an open punch list item, a half-written file from yesterday, a save that didn't happen, a pattern that's been recurring.
+4. **Surface 1-3 things first.** Pick what matters most: an unresolved blocker, an open punch list item, a half-written file from yesterday, a save that didn't happen, a pattern that's been recurring.
 
 ## Format
 

--- a/commands/where-is.md
+++ b/commands/where-is.md
@@ -20,11 +20,13 @@ Query: `${ARGUMENTS}`. If empty, ask what they're looking for and stop.
 
 1. **Read the house-map first** — it's your index.
    ```bash
-   SLUG="$(pwd | sed 's|/|-|g')"
-   MAP="$(pwd)/.maude/plugin/house-map.md"
+   PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+   MAP="$PROJ/.maude/plugin/house-map.md"
    [ -f "$MAP" ] && cat "$MAP"
    ```
-   If the map mentions the thing or a directory likely to contain it, look there first.
+   If the map mentions the thing or a directory likely to contain it, look there first. The
+   map's `## Memory sources` entries (with their `path:` fields) are the authoritative index
+   for where memory lives — prefer them over a blind workspace grep.
 
 2. **Grep the workspace:**
    ```bash

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,5 +1,5 @@
-<!-- Version: 2.0 -->
-<!-- Revised: 2026-05-04 MST — plugin-only -->
+<!-- Version: 0.1.7 -->
+<!-- Revised: 2026-05-24 MST — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Skill

--- a/skills/maude/SKILL.md
+++ b/skills/maude/SKILL.md
@@ -94,8 +94,8 @@ The house-map is a simple Markdown file Maude maintains at `<project>/.maude/plu
 # Updated: <last update timestamp>
 
 ## Memory sources (tier-classified, populated by /maude:found)
-- anthropic-auto-memory | tier: 0 | shape: markdown | path: ~/.claude/projects/<slug>/memory/ | recall: grep+cat | write: append (now.md, today-*.md, recent.md)
-- remember-plugin       | tier: 0 | shape: markdown | path: <project>/.remember/ | recall: grep+cat | write: remember.md only (handoff format)
+- anthropic-auto-memory | tier: 0 | shape: markdown | path: ~/.claude/projects/<slug>/memory/ | recall: grep+cat | write: digest-fanout (now.md, today-*.md, recent.md)
+- remember-plugin       | tier: 0 | shape: markdown | path: <project>/.remember/ | recall: grep+cat | write: handoff-only (remember.md)
 - maude-self            | tier: 0 | shape: markdown | path: <project>/.maude/plugin/ | recall: grep+cat | write: full
 - user-global           | tier: 0 | shape: markdown | path: ~/.claude/maude/ | recall: grep+cat | write: full (patterns.md, identity.md, projects.json)
 - (everything else discovered on the walk — paths, shapes, and what the user told her about each — goes here as flat entries the user can edit)
@@ -137,6 +137,41 @@ The house-map is a simple Markdown file Maude maintains at `<project>/.maude/plu
 ```
 
 The map is editable. The user can add notes, remove things, correct her. She re-reads it every time before acting.
+
+### The `write:` field is authoritative
+
+`write:` is not a description — it is the **instruction** save/rest obey for that source.
+It leads with **one token** from the fixed vocabulary below; free prose may follow as an
+annotation (e.g. `handoff-only (remember.md)`). The writers read the leading token and act
+on it. Because the map is editable, changing a source's token *changes what save/rest do* —
+that is the point: the map governs, not hard-coded paths.
+
+| Token | What save/rest do | Typical source |
+|---|---|---|
+| `digest-fanout` | Overwrite the live buffer (`now.md`) with the digest; append a `## TIME \| topic` block to `today-<date>.md`; append one line to `recent.md`. Written for next-session **Claude's continuity** — not as Maude's own store. | anthropic-auto-memory |
+| `handoff-only` | Write ONLY the source's single handoff file (e.g. `remember.md`) in its handoff format. **Never** touch any other file in that dir — pipeline output belongs to the owning system. | remember-plugin |
+| `full` | Maude owns this store — write any of her own files freely. | maude-self, user-global |
+| `read-only` | Recall only. Never write. | user dirs marked read-only |
+| `secret-deny` | Never write, never echo contents; read only on explicit typed ask. | secrets / credential vaults |
+
+Each entry also carries `tier:`. The writers apply the **tier gate first** (Tier 0 always;
+Tier 1 only if `tier1_up` cached; Tier 2 only if registered writable + auth env set), then
+the `write:` token.
+
+**Unrecognized or malformed token** (typo, or a token from a vocabulary version she
+doesn't know) → **skip the source and surface a one-line warning** in the report. Never
+guess an action from an unknown token — fail safe (no write), fail loud (named in output).
+
+### Fallback when the map is silent
+
+- **Map present + source listed** → the map wins, period (tier gate × token).
+- **Map absent, OR a universal source not listed** → documented defaults only:
+  - Anthropic auto-memory (`$MEM`) if the dir exists → `digest-fanout`
+  - `.remember/remember.md` if `.remember/` exists → `handoff-only`
+
+Defaults fire ONLY when the map says nothing — so a fresh project with no walk still saves,
+but an edited map is never overridden by hard-code. These are the two universal conventions
+Maude ships knowing; everything else must be on the map to be written.
 
 ## Workflows (and what their slash commands do)
 


### PR DESCRIPTION
The house-map already registered every memory source, but the commands
didn't obey it: save/rest hard-coded the two common stores (Anthropic
auto-memory + .remember/) by directory check, so editing the map's write:
rule for them was silently ignored. This wires the map as the single
source of truth so "she works with whatever's there" is enforced by the
mechanism, not just stated in identity.md.

- write: is now an authoritative token (digest-fanout / handoff-only /
  full / read-only / secret-deny), executed deterministically; unknown
  tokens fail safe (skip) and loud (named in report).
- save.md / rest.md write per each source's tier gate x write: token.
- read commands (wake / brief / remind-me) recall per each source's
  recall: method; where-is resolves the map via CLAUDE_PROJECT_DIR.
- found.md stamps a token per source on the walk.
- fallback: universal defaults fire only when the map is silent, never
  overriding a listed entry.

Also corrected stale standalone Version: headers (6.0.0 / 6.0 / 5.0 /
2.0) across docs to the real plugin line (0.1.7).

Local audit: maude-verify version consistency green (canonical 0.1.7).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
