### PR TITLE
Add X badge to README social row

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Status: Beta](https://img.shields.io/badge/Status-Beta-orange.svg)](#)
 
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/john-broadway)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/john-broadway) [![X](https://img.shields.io/badge/X-000000?logo=x&logoColor=white)](https://x.com/jebroadway)
 
 </div>
 


### PR DESCRIPTION
Adds an X (@jebroadway) badge alongside LinkedIn in the social row. Verified: logo=x renders the real X glyph (logo=twitter is blank/dead slug). Phase 0 + team + Haiku redteam run; redteam's logo HIGH was empirically disproven by fetching the SVG. make test 16/16, make verify 0 findings.