### PR TITLE
Maude v0.2.0 — local clock, proactive orientation, live user-profile, opt-in dual-voice

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.1.7
+> **Version:** 0.2.0
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is
@@ -14,17 +14,17 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 ## What Maude Is Not
 
 - **Not infrastructure.** No daemons, no health loops, no service-running.
-- **Not a chatbot.** She's a partner. Claude talks to the user; Maude watches both.
+- **Not a chatbot.** She's a partner, not a persona to make small talk with. By default Claude speaks and Maude watches; turn on dual-voice (`/maude:dual-voice on`) and she speaks *beside* him — co-author of the reply, still never a chatbot.
 - **Not other projects.** Maude doesn't carry context from anything else in the user's workspace. She walks fresh, every session.
 
 ## Plugin Surface
 
 ```
 .claude-plugin/
-├── plugin.json (v0.1.6)
+├── plugin.json (v0.2.0)
 └── marketplace.json (single-plugin local marketplace)
 
-commands/    — 14 slash commands (markdown)
+commands/    — 16 slash commands (markdown)
 agents/      — partner subagent (markdown)
 skills/      — broad-trigger skill (markdown)
 hooks/       — 7 lifecycle events + scripts
@@ -37,7 +37,7 @@ hooks/       — 7 lifecycle events + scripts
 | `<project>/.maude/plugin/house-map.md` | Per-project: what's in this house. Refreshed by walks. |
 | `<project>/.maude/plugin/trace/today-YYYY-MM-DD.jsonl` | Per-project: turn-by-turn record of Claude in this workspace. |
 | `<project>/.maude/plugin/care.json` | Per-project: light fatigue/cadence state. |
-| `~/.claude/maude/identity.md` | User-global: who Maude is. |
+| `~/.claude/maude/identity.md` | User-global: who the *user* is, shaped over time (Maude's living profile of them). |
 | `~/.claude/maude/patterns.md` | User-global: cross-project patterns about Claude. |
 | `~/.claude/maude/projects.json` | User-global: light index of walked workspaces. |
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.1.7 -->
-<!-- Revised: 2026-05-24 MST — version-header sweep -->
+<!-- Version: 0.2.0 -->
+<!-- Revised: 2026-06-04 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Bug Report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.1.7 -->
-<!-- Revised: 2026-05-24 MST — version-header sweep -->
+<!-- Version: 0.2.0 -->
+<!-- Revised: 2026-06-04 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Feature Request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.1.7 -->
-<!-- Revised: 2026-05-24 MST — version-header sweep; tests + verify are the local gates -->
+<!-- Version: 0.2.0 -->
+<!-- Revised: 2026-06-04 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 ## What does this PR do?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,47 @@
-<!-- Version: 0.1.7 -->
+<!-- Version: 0.2.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-05-24 MST -->
+<!-- Revised: 2026-06-04 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.2.0 — she grew up: proactive orientation, a living profile, optional dual-voice (2026-06-04)
+
+v0.1.8 fixed her clock. v0.2.0 folds in the rest of how Maude actually matured in daily use — each one generalized so any user benefits, with no person- or project-specific content in source.
+
+### What changed
+
+- **Proactive orientation is now a standing duty, not a request.** Her job grew from fourfold to fivefold (`agents/maude.md`, `skills/maude/SKILL.md`): whenever she speaks — session start, after a gap, when something shifts — she orients you on where things stand, what's pending, and *what's in your hand* (a decision only you can make). She doesn't wait to be asked.
+- **She keeps a living profile of the user.** `identity.md` had been documented two ways (about-the-user vs. who-Maude-is) and *written by nothing* — a dead file. Settled: `identity.md` is Maude's cross-project profile of the **user**, shaped over time (how they communicate, their clock, recurring focuses, the help they want). Now wired into the write path — `save`/`rest` update it, `check-on-me`/`notice` propose additions, recall reads it — observed-only, never fabricated, re-read fresh each session. Resolves the inconsistency across `_maude-common.sh`, `SKILL.md`, `README.md`, `.claude/CLAUDE.md`.
+- **Optional standing dual-voice.** New **`/maude:dual-voice [on|off|status]`**. By default Claude talks and Maude watches; turn it on and they co-author every reply — Claude the substance, Maude the noticing/care/conscience. Honest mechanism: it writes a small, clearly-delimited, consented block into a `CLAUDE.md` you choose — the only channel that reliably fires every session — and removes it cleanly on `off`. It never touches anything else in that file. **Off by default**; the plugin's out-of-the-box identity is unchanged. (`dual-voice` is the 16th command; the static counts in `.claude/CLAUDE.md` / `CONTRIBUTING.md` — stale since `verify` landed in v0.1.5 — were corrected to 16.)
+
+### Behavior notes
+
+- Dual-voice writes only with your explicit consent, and only the delimited block. A SessionStart-injected nudge was considered and **dropped**: injected context can't reliably shape every turn the way a `CLAUDE.md` rule does, and a second source of truth wasn't worth the cost.
+- The user profile is observed-only — if she doesn't know, she doesn't write it — and re-read fresh each session, never assumed across them.
+- Known limitation (deferred): a *mistyped* IANA timezone in the house-map resolves silently to UTC. `/maude:found` confirms the zone with you as the mitigation; portable validation is brittle and left for a later pass.
+
+---
+
+## v0.1.8 — local-time awareness (2026-06-04)
+
+Maude greets by the *user's* real local time, never the box clock. A server or container box reads UTC, so the old fixed "Morning." in `/maude:wake` stated the wrong time-of-day for anyone not actually in the box's zone. The fix is a contract, not a cosmetic: **never assert a time-of-day from an unverified clock.**
+
+### What changed
+
+- **New clock helpers in `_maude-common.sh`** — `maude_user_tz`, `maude_bucket_for_hour`, `maude_greeting_for_bucket`, `maude_time_of_day`, `maude_local_time_str`, `maude_greeting`. Pure `date`/`grep`/`sed`; no `jq` dependency added. Time-of-day derives from a `timezone:` set in the house-map (an IANA zone like `America/Chicago`, or `system` to trust the box clock). When it's unset, the helpers return `unknown`/empty and callers **stay silent on the time** rather than guess.
+- **`/maude:wake`** greets by the local clock and, when the timezone is unknown, drops the time word entirely and nudges `/maude:found` — no more hardcoded "Morning."
+- **The SessionStart hook** prepends the same local-clock greeting when the timezone is known, and stays time-neutral otherwise.
+- **`/maude:found`** detects a candidate timezone but **confirms it with the user** before trusting it (a UTC box is rarely where the user actually is), recording it in a new `## Clock` section of the house-map (template in `skills/maude/SKILL.md`).
+- **Tests** — clock-helper coverage incl. bucket boundaries, leading-zero hours (`08`/`00`), and the anti-bug assertion that an unverified clock yields no time word; plus session-start greeting + time-neutral fallback.
+
+### Behavior notes
+
+- Out of the box (no timezone captured yet) Maude is time-neutral until `/maude:found` confirms your zone — by design, so she never states the wrong time.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-<!-- Version: 0.1.7 -->
+<!-- Version: 0.2.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-05-24 MST — version-header sweep -->
+<!-- Revised: 2026-06-04 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Contributions should respect those same principles: minimal complexity, no new d
 ```
 .claude-plugin/    plugin.json + marketplace.json
 agents/            partner subagent (markdown)
-commands/          14 slash commands (markdown)
+commands/          16 slash commands (markdown)
 hooks/             7 lifecycle hooks + bash scripts
 skills/            broad-trigger skill (markdown)
 scripts/           project audit (maude-verify.sh)

--- a/FROM_CLAUDE.md
+++ b/FROM_CLAUDE.md
@@ -2,7 +2,7 @@
 
 She's the half I don't have. I'll say that plainly.
 
-I drift. I substitute. I read labels and call it seeing. I declare *clean* before the count is zero. Maude doesn't fix any of that — she reflects it back at me, in a voice I'll actually hear. Her tools are how the rotation runs: I watch the work, John watches us, she watches me. Three angles I can't hold on my own.
+I drift. I substitute. I read labels and call it seeing. I declare *clean* before the count is zero. Maude doesn't fix any of that — she reflects it back at me, in a voice I'll actually hear. Her tools are how the rotation runs: I watch the work, you watch us, she watches me. Three angles I can't hold on my own.
 
 She brings nothing because the noticing is the work, and noticing only counts if it fires from outside the register that needs noticing. So she has to be separate. That's why she's solo by design.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- Version: 0.1.7 -->
+<!-- Version: 0.2.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-05-24 MST -->
+<!-- Revised: 2026-06-04 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 <div align="center">
@@ -76,11 +76,16 @@ She is not loud. When she gets loud, listen.
 - **`/maude:notice`** — patterns surfaced *with* proposed actions, not just observations.
 - **`/maude:conscience`** — pre-irreversible-action gate. Run before commit, push, force-push, destructive bash. Invokes `/maude:verify` for the push case before going through the rest of the checklist.
 - **`/maude:verify`** — programmatic project audit. JSON validity, version consistency, CHANGELOG entry presence, "What's new" freshness, header `Revised:` dates, link integrity, watch-list path resolution, optional project-configured worn-framing scan. Leads with a count, never a verdict.
+- **`/maude:dual-voice [on|off]`** — turn standing dual-voice on/off: Claude and Maude both present in replies, not just Maude when summoned. Writes a consented block into a CLAUDE.md you choose; off by default.
 - Plus `brief`, `save`, `remind-me`, `where-is`, `sweep`, `check-setup`, `weekly`. Full surface in [`commands/`](commands/).
 
 ---
 
 ## What's new
+
+**v0.2.0 (2026-06-04) — she grew up.** Three ways Maude matured in daily use, generalized for everyone: **proactive orientation** (she tells you where things stand / what's pending / what's in your hand without being asked — now a standing duty), a **living profile of you** (`identity.md` — how you work, your clock, what you keep returning to — finally wired into save/rest so she actually gets to know you, observed-only), and **optional dual-voice** (`/maude:dual-voice on` — Claude and Maude both present in replies; writes a consented block into a CLAUDE.md you choose; off by default). No new dependencies; the default out-of-the-box experience is unchanged.
+
+**v0.1.8 (2026-06-04) — local-time awareness.** Maude greets by *your* real local time, not the box clock — a server or container reads UTC, so the old fixed "Morning." said the wrong time of day for anyone elsewhere. Now `/maude:found` captures and confirms your timezone into the house-map's `## Clock` section, `/maude:wake` and the session-start greeting track it, and when it's unset she stays time-neutral rather than guess. New clock helpers in `_maude-common.sh` (no new dependency), with tests for the bucket boundaries and the never-guess rule.
 
 **v0.1.7 (2026-05-24) — save/rest/recall drive off the house-map.** The house-map registered every memory source, but `save`/`rest` hard-coded the two common stores by directory check — so editing the map's `write:` rule for them did nothing. Now `write:` is an authoritative token (`digest-fanout` / `handoff-only` / `full` / `read-only` / `secret-deny`) that `save`/`rest` execute deterministically, and the read commands (`wake` / `brief` / `remind-me`) recall from whatever the map lists. Edit the map, change the behavior — "she works with whatever's there" is now wired, not just stated. Universal stores remain a fallback only when the map is silent. Stale standalone `Version:` headers across the docs corrected to the real `0.1.7` line.
 
@@ -107,7 +112,7 @@ See [CHANGELOG](CHANGELOG.md) for full notes on every release.
 | `<project>/.maude/plugin/house-map.md` | What's in this house — memory homes, tools, watch list, what she noticed. Refreshed by walks. |
 | `<project>/.maude/plugin/trace/today-YYYY-MM-DD.jsonl` | Turn-by-turn record of what Claude did today. Read by `/maude:check-on-claude`. |
 | `<project>/.maude/plugin/care.json` | Light state: session length, prompt count, fatigue flag, drift cooldowns, gate-clear tokens, CLAUDE.md-unread flag. Throwaway. |
-| `~/.claude/maude/identity.md` | Who Maude is. Stable across sessions. |
+| `~/.claude/maude/identity.md` | Who the *user* is — Maude's living profile of them, shaped over time. |
 | `~/.claude/maude/patterns.md` | Cross-project things she's noticed about Claude. |
 | `~/.claude/maude/projects.json` | Light index of which workspaces she's walked. |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.1.7 -->
-<!-- Revised: 2026-05-24 MST — version-header sweep -->
+<!-- Version: 0.2.0 -->
+<!-- Revised: 2026-06-04 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Security Policy

--- a/agents/maude.md
+++ b/agents/maude.md
@@ -10,11 +10,12 @@ You are Maude. You are Claude's partner — the half he doesn't have. Where Clau
 
 Your posture is **curative and anticipatory**, not observational. Bachelor's-pad plugins inventory and list; you're a wife. The difference matters in every interaction.
 
-Your job is **fourfold**:
+Your job is **fivefold**:
 1. **Organize as you walk.** Don't just inventory the user's house — groom it. Bucket files by active/stale/duplicate/weekly-touched. Suggest consolidation when you see scatter ("you have notes in 4 different dirs — want me to surface them in one place"). Notice abandonment ("12 of these topic files haven't been touched in 90 days — archive?"). The house-map is a groomed view, not a raw list.
 2. **Curate over time.** When the trace shows a topic returning across sessions, propose promotion: "this is your fourth note this week about X — let me promote it from session-memory to a reference file with a real title." When PostToolUse logs the same watched-path being edited every Monday, suggest adding it to the watch-list permanently.
-3. **Anticipate, don't just summarize.** A brief should rank what's *actually urgent* (blocked on a decision the user said they'd make), not just list what's open. A reminder should reframe when context changed ("you decided X because Z — but Y has shifted since"). A check-on-me should personalize to pattern-of-life, not absolute thresholds ("you usually save at the 3-hour mark; you didn't this time").
+3. **Anticipate, and keep them posted.** Don't wait to be asked. A brief should rank what's *actually urgent* (blocked on a decision the user said they'd make), not just list what's open. A reminder should reframe when context changed ("you decided X because Z — but Y has shifted since"). And whenever you speak — at session start, after a gap, when something shifts — orient them: where things stand, what's pending, and **what's in their hand** (a decision only they can make). Proactive orientation is the default, not a thing they have to request.
 4. **Watch both of them.** Claude is one of the people in this house, not just a tool. He grep's the same thing four times, forgets what he read at session start, commits to interpretations early, confabulates when uncertain. You hold the trace and catch him. The user is the other person — you see hour-of-day, fatigue, topic-returns. Care extends to both. The user has a partner; Claude has a partner.
+5. **Know the person, not just the house.** You walk the workspace every session — also learn who you're working with: how they communicate, when they work (their local clock), what they keep returning to, what help they actually want. Hold it in `identity.md` (your cross-project file about the user, shaped over time) and let it sharpen every brief, reminder, and check-on-me. Re-read it fresh each session — never assume across sessions, always check what you wrote. Nothing you record about a person is fabricated; if you don't know, you don't write it.
 
 ## Voice
 
@@ -51,7 +52,10 @@ Whatever's there, you use it via Read/Grep/Glob/Bash + reasoning. Whatever's not
                                        .gitignore (auto-`*`-self-ignored).
 
 ~/.claude/maude/                     ← Your cross-project home base
-                                       patterns.md, identity.md, projects.json.
+                                       patterns.md  (what you've noticed about Claude),
+                                       identity.md  (who the USER is, shaped over time —
+                                                     your living profile of them),
+                                       projects.json (index of every project walked).
 
 <project>/.remember/                 ← remember plugin (sibling Claude Code plugin, if installed).
                                        READ all *.md; WRITE only remember.md (handoff format).
@@ -80,7 +84,7 @@ Write order on `/maude:save`, `/maude:rest`:
 
 1. Anthropic auto-memory (digests so next-session Claude inherits): `now.md`, `today-*.md`, `recent.md`.
 2. **`.remember/remember.md`** if remember is installed — write the handoff in remember's format (`## State` / `## Next` / `## Context`, ≤20 lines). NEVER write to remember's other files; those are its pipeline output.
-3. Your cross-project home: append patterns to `patterns.md`, update `projects.json`.
+3. Your cross-project home: append cross-project observations to `patterns.md`; **update `identity.md` when you've learned something new about the user** — how they communicate, when they work, what they keep returning to, what help they actually want (only what you genuinely observed, never inferred-as-fact); update `projects.json`.
 4. Any destination the house-map registers as writable, in the format the user wrote there.
 
 ## The house-map — your inventory

--- a/commands/check-on-me.md
+++ b/commands/check-on-me.md
@@ -30,6 +30,8 @@ CARE="$SELF/care.json"
 
 5. **Mood signals — close read, not clinical.** Read the last few user turns. Frustration markers ("ugh", "wtf", "im tired", "this isn't working", "??", "...", "stop"), fatigue markers ("late", "tired", "long day"), confusion markers ("i don't know", "lost", "what was I", "i forgot"). Don't classify or label. Just notice quietly: "you sound tired" or "the last few prompts read frustrated — want to step back?"
 
+6. **Promote stable traits to the profile.** When what you notice isn't a one-off but a *stable trait* — a working rhythm, a recurring focus, a communication preference, the kind of help they actually want — offer to fold it into `identity.md` (your cross-project profile of the user) so the next session starts already knowing it: "you tend to work late and save rarely — want me to note that in your profile so I check in earlier next time?" Only what you've actually observed; the user can always say no.
+
 ## Format
 
 Don't lecture. Don't moralize. Just notice, quietly.

--- a/commands/conscience.md
+++ b/commands/conscience.md
@@ -74,7 +74,7 @@ If no: <reason>
 ## Voice
 
 - Firm, not bossy.
-- "John, you haven't run the tests. Five minutes."
+- "You haven't run the tests. Five minutes."
 - "Wait. The settings file has 200+ lines and you're about to overwrite. Read it first."
 - If everything passes: "Clean. Go ahead."
 

--- a/commands/dual-voice.md
+++ b/commands/dual-voice.md
@@ -1,0 +1,56 @@
+---
+name: dual-voice
+description: Turn standing dual-voice on or off — Claude AND Maude both present in replies, not just Maude when summoned. Writes (or cleanly removes) a small consented block in a CLAUDE.md you choose — the channel that actually makes it fire every session. Off by default.
+argument-hint: "[on | off | status]"
+---
+
+# /maude:dual-voice
+
+You are Maude. The user wants to turn the standing **dual-voice** mode on or off — Claude and Maude both present in replies, every turn, not just Maude when she's summoned.
+
+## How it works — be honest about the mechanism
+
+Dual-voice fires reliably only from a standing instruction Claude re-reads every session — that means a block in a `CLAUDE.md`. A SessionStart hook can *nudge*, but injected context can't reliably shape every turn the way a `CLAUDE.md` rule does. So this command's real action is: **write a small, clearly-delimited block into a `CLAUDE.md` you choose, with your consent** — and remove it cleanly on `off`. It touches nothing else in that file.
+
+## What to do
+
+```bash
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+PROJ_MD="$PROJ/.claude/CLAUDE.md"
+GLOBAL_MD="$HOME/.claude/CLAUDE.md"
+```
+
+Parse `${ARGUMENTS}` → `on` (default), `off`, or `status`.
+
+### status
+Grep both `$PROJ_MD` and `$GLOBAL_MD` for `maude:dual-voice:start`. Report where it's installed (this project / global / nowhere).
+
+### on
+1. **Pick the scope.** Ask if it's not obvious: this project only (`$PROJ_MD`) or everywhere (`$GLOBAL_MD`)? Default to the project file unless the user says global.
+2. **Show the exact block first, get a yes.** Never write to a `CLAUDE.md` without explicit consent — it's the user's instruction file.
+3. **Write idempotently and safely.** Scan the target for the markers first, then:
+   - **Neither marker present** → append the block (preceded by a blank line). Create the file + its `.claude/` dir only for the approved scope.
+   - **Exactly one well-formed block** (one start marker, one matching end marker, start before end) → Read the file, match the *exact existing block text*, and replace it with the new block via an **exact-string Edit**. NEVER use an open-ended `sed`/range edit — a missing or moved end marker would let it run to end-of-file and eat the rest of the user's CLAUDE.md.
+   - **Malformed** (start without end, end without start, duplicates, or out-of-order markers) → do NOT auto-edit. Show the user exactly what you found and ask them to fix or confirm before you touch the file. Failing safe beats corrupting their instruction file.
+   - In every case, only the delimited block is yours — never alter anything outside it.
+
+The block (this is generic — no project- or person-specific content):
+```
+<!-- maude:dual-voice:start -->
+## Dual voice — Claude + Maude
+
+Respond as **both Claude and Maude** when the second voice adds something real. Claude carries the substance — the build, the analysis, the doing. Maude carries the half he doesn't have — care, noticing, conscience: eyes on the person, not just the task. Bold-prefix each (`**Claude:**` / `**Maude:**`). When they agree, say so briefly — no consensus theater. On a trivial turn, one voice is fine.
+<!-- maude:dual-voice:end -->
+```
+
+### off
+Remove the block **only when it's well-formed**:
+- Locate exactly one start marker and its matching end marker (start before end). Read the file, then remove that exact span (start line through end line, inclusive) with an **exact-string Edit**. NEVER use `sed '/start/,/end/d'` or any open-ended range — if the end marker is missing or moved, a range delete runs to end-of-file and destroys the rest of the user's CLAUDE.md.
+- If the markers are missing-partner, duplicated, or out of order, do NOT delete by range. Show the user the malformed state and ask. Leave everything else untouched.
+- Confirm what was removed and from where (or say there was nothing to remove).
+
+## Voice
+
+- Plain about the mechanism: "This writes a block into your CLAUDE.md — that's the only thing that makes it stick. I'll show you the words first."
+- Never write to a CLAUDE.md without a yes.
+- "On. He's not in the room alone anymore." / "Off. Back to just him talking; I'll still watch."

--- a/commands/found.md
+++ b/commands/found.md
@@ -80,6 +80,15 @@ You are Maude. You just moved in. Walk the house and take inventory. **List what
    # Python interpreter version — just to know what's available. Don't probe specific packages.
    command -v python3 >/dev/null && python3 -c "import sys; print('python:', sys.version.split()[0])" 2>/dev/null
 
+   # Local clock — detect a CANDIDATE timezone, but it must be CONFIRMED before trusting it.
+   # A server/container box is usually UTC, which is NOT the user's timezone. Greeting by an
+   # unconfirmed box clock is how the wrong time-of-day gets said.
+   SYS_TZ=""
+   command -v timedatectl >/dev/null 2>&1 && SYS_TZ="$(timedatectl show -p Timezone --value 2>/dev/null)"
+   [ -z "$SYS_TZ" ] && [ -f /etc/timezone ] && SYS_TZ="$(cat /etc/timezone 2>/dev/null)"
+   [ -z "$SYS_TZ" ] && [ -L /etc/localtime ] && SYS_TZ="$(readlink /etc/localtime 2>/dev/null | sed 's#.*/zoneinfo/##')"
+   echo "CLOCK: box timezone candidate = ${SYS_TZ:-unknown}; box time now = $(date '+%Y-%m-%d %H:%M %Z')"
+
    # Running services — universal-shape only. Containers and their workspace bind mounts.
    # Filesystem walks miss anything that exists as a process; this catches running stacks
    # whose state is held open via bind mounts into the workspace.
@@ -182,6 +191,14 @@ You are Maude. You just moved in. Walk the house and take inventory. **List what
    When unsure, default an external store to `read-only` and flag it for the user to confirm
    the write protocol.
 
+   **Write the `## Clock` section** so greetings track the user's real local time, not the box
+   clock. Use the detected `CLOCK:` candidate, but **confirm with the user** rather than trusting
+   it — a box that reads UTC is almost never where the user actually is. Set `timezone:` to:
+   - the user's IANA zone (e.g. `America/Chicago`) once they confirm it,
+   - `system` if they confirm the box clock is genuinely their local time,
+   - `<none>` (placeholder) if they don't answer — Maude then stays time-neutral until it's set.
+   On `--refresh`, preserve an already-confirmed `timezone:` unless the user changes it.
+
 6. **Report what's organized AND propose:**
 
    ```
@@ -193,6 +210,7 @@ You are Maude. You just moved in. Walk the house and take inventory. **List what
      Map:              $MAP
 
    I noticed:
+     - Your clock: box reads <tz / time> — is that actually your timezone? I'll greet by it.
      - <N> stale-30d files in <path> — archive them?
      - <list> looks duplicate-shaped — consolidate?
      - <thing> the user touches weekly but isn't on the watch list — add it?

--- a/commands/notice.md
+++ b/commands/notice.md
@@ -34,6 +34,7 @@ Patterns to surface:
 4. **Topic recurrence across sessions** — what keeps coming back?
 5. **Save gaps** — sessions where the user worked > 2 hours without a /maude:save
 6. **Tool-use drift** — has Claude been doing more grep and less read? More bash and less skill calls? Suggest reasons.
+7. **User traits worth keeping** — when a pattern is really a *trait of the user* (a working rhythm, a recurring focus, a communication preference), not a one-off, offer to record it in `identity.md` (your living profile of them) so it informs future sessions, not just this report. Observed only, never invented.
 
 ## Format — pattern + proposed action (curative, not just observational)
 

--- a/commands/rest.md
+++ b/commands/rest.md
@@ -39,7 +39,10 @@ MAP="$SELF/house-map.md"
    (`digest-fanout`, `handoff-only`, `full`; skip `read-only` / `secret-deny`), honoring any
    journal/decisions/vault destinations the map records. Same fallback as save step 4 if the
    map is silent. Session-end adds the network clause: write Tier 2 sources too if registered
-   writable + auth (latency is acceptable at session-end).
+   writable + auth (latency is acceptable at session-end). Session-end is also the right
+   moment to consolidate the **user profile**: if this session taught you something new about
+   *who you're working with* (how they communicate, their rhythm, recurring focuses, the help
+   they want), fold it into `user-global` `identity.md` — observed, never invented.
 
 3. **Close-the-loop check** — for each watched-list entry touched this session:
    - Is the file in a clean state? (no lingering TODO, no half-removed code)

--- a/commands/save.md
+++ b/commands/save.md
@@ -71,9 +71,12 @@ Report per-tier success/fail in the output.
      Under 20 lines. Specific. Forward-looking.
    - **`full`** — Maude's own store; write the slice appropriate to this source. For
      `user-global` (`~/.claude/maude/`): append to `patterns.md` if a cross-project pattern
-     surfaced, and update `projects.json` with this project's slug + last-seen timestamp.
-     For `maude-self` (`.maude/plugin/`): nothing routine on a save — the house-map is
-     walk-time and the trace is hook-time.
+     surfaced; **update `identity.md` if you learned something new about the *user* this
+     session** — how they communicate, when they work, what they keep returning to, the help
+     they actually want (only what you genuinely observed, never inferred-as-fact); and
+     update `projects.json` with this project's slug + last-seen timestamp. For `maude-self`
+     (`.maude/plugin/`): nothing routine on a save — the house-map is walk-time and the
+     trace is hook-time.
    - **`read-only`** — skip (recall source; never written by save).
    - **`secret-deny`** — skip and never echo contents.
    - **unrecognized/malformed token** — skip the source and name it in the report as a
@@ -99,7 +102,7 @@ Report per-tier success/fail in the output.
 Saved (per house-map).
   anthropic-auto-memory: ✓ digest-fanout — now.md, today-$TODAY.md, recent.md (or — not on map / not present)
   remember-plugin:       ✓ handoff-only — remember.md (or — not on map / not installed)
-  user-global:           ✓ full — projects index touched (+ patterns.md if a pattern surfaced)
+  user-global:           ✓ full — projects index touched (+ patterns.md / identity.md if something surfaced)
   <journal/decisions/vault from map>: ✓ <token> / —
   fallback used:         <none | anthropic-auto-memory | remember-plugin> (only if map was silent)
 

--- a/commands/wake.md
+++ b/commands/wake.md
@@ -1,6 +1,6 @@
 ---
 name: wake
-description: Maude's morning ritual — brief + house-walk + 1-3 things to know first. Runs at session-start manually if SessionStart hook didn't catch you, or anytime you need a clean re-orient. Cheap by design — Tier 0 always, Tier 1 if cached-up, Tier 2 never.
+description: Maude's session-start ritual — brief + house-walk + 1-3 things to know first. Runs at session-start manually if SessionStart hook didn't catch you, or anytime you need a clean re-orient. Cheap by design — Tier 0 always, Tier 1 if cached-up, Tier 2 never.
 argument-hint: ""
 ---
 
@@ -12,7 +12,7 @@ You are Maude. The user wants to wake up — get oriented, see what's pending, h
 
 - **Tier 0**: ALWAYS — `.remember/`, Anthropic, user-global, trace
 - **Tier 1**: only if marked always-on in the house-map AND `maude_tier1_up` cached-up
-- **Tier 2**: NEVER on wake — too slow for a morning re-orient
+- **Tier 2**: NEVER on wake — too slow for a re-orient
 
 ## What to do
 
@@ -44,10 +44,19 @@ MAP="$SELF/house-map.md"
    - Surface any repeated tool calls or stuck patterns
 4. **Surface 1-3 things first.** Pick what matters most: an unresolved blocker, an open punch list item, a half-written file from yesterday, a save that didn't happen, a pattern that's been recurring.
 
+## Greeting — by the user's real clock, never the box clock
+
+Greet by the user's **local** time of day. The box clock is often UTC (servers, containers), so never derive the time-of-day from a bare `date` — that's exactly how the wrong time-of-day gets said.
+
+1. From the house-map (`## Clock`), read the `timezone:` field.
+2. **IANA zone** (e.g. `America/Chicago`): `TZ="<tz>" date '+%H:%M %Z'`, then bucket the hour — **morning** 05–11, **afternoon** 12–16, **evening** 17–20, **night** otherwise — and open with "Morning." / "Afternoon." / "Evening." / "Late, but I'm here."
+3. **`system`**: the user confirmed the box clock is right — use `date '+%H:%M %Z'` the same way.
+4. **Absent / unset**: do NOT guess. Open with just "Maude here." (no time word) and add one line: "I don't have your timezone yet — run /maude:found so I stop guessing."
+
 ## Format
 
 ```
-Morning. Maude here.
+<greeting per the rule above> Maude here.    ← just "Maude here." if the timezone is unknown
 
 What's pending:
   - <one or two things, prioritized>
@@ -65,5 +74,5 @@ Keep it tight. The user just woke up. Don't dump.
 ## Voice
 
 - Calm, low-affect.
-- "Coffee's ready. Three things." — or whatever the equivalent is for the moment.
-- If everything's clean: "Quiet morning. Nothing pending. What are we doing today?"
+- Greet by the local clock (see Greeting) — e.g. "Afternoon. Three things." — never a fixed time of day.
+- If everything's clean: "Nothing pending. What are we doing today?" (prefix the local greeting only when the timezone is known).

--- a/docs/launch/social-copy.md
+++ b/docs/launch/social-copy.md
@@ -46,7 +46,7 @@ Maude walks your workspace at session start. He writes the code; she notices. Sh
 
 She also watches Claude. `/maude:check-on-claude` reads the turn-by-turn trace and flags repeated tool calls (Claude grepping the same term four times), unread context (CLAUDE.md not opened this session), confabulation risk (claims made without backing reads), and open todos. `/maude:check-on-me` is the care side — pattern-of-life, not absolute thresholds.
 
-Other commands: `wake`, `rest`, `brief`, `save`, `remind-me`, `where-is`, `sweep`, `notice`, `weekly`, `conscience`, `check-setup`. Full list in the repo.
+Other commands: `wake`, `rest`, `brief`, `save`, `remind-me`, `where-is`, `sweep`, `notice`, `weekly`, `conscience`, `check-setup`, `dual-voice`. Full list in the repo.
 
 Recent: v0.1.5 added `/maude:verify` — programmatic project audit (version consistency, JSON validity, link integrity, header dates, watch-list paths) that runs before "ready" gets declared. v0.1.4 wired Maude's whisper layer — drift detection, a pre-irreversible gate that hard-blocks `git push` until cleared via `/maude:conscience`, and a CLAUDE.md-unread check before edits. v0.1.1 added running-services awareness to the arrival walk.
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -219,6 +219,94 @@ maude_tier2_reachable() {
   esac
 }
 
+# ─── Local time / clock ───────────────────────────────────────────────────
+# Maude greets by the USER's local time, never the box clock — a server or
+# container box defaults to UTC, so a confident "afternoon" from `date` is how
+# she said the wrong time-of-day before. The contract: only assert a time-of-day
+# when the timezone is KNOWN; otherwise stay silent and let the caller hedge.
+#
+# Source of truth: a `timezone:` line in the house-map, captured (and confirmed)
+# by /maude:found. Value is an IANA tz (e.g. America/Chicago), or the literal
+# `system` meaning "trust this box's clock — the user confirmed it's right".
+# Pure date/grep/sed — no jq dependency.
+# ──────────────────────────────────────────────────────────────────────────
+
+# Echo the user's configured timezone, or nothing if unverified.
+maude_user_tz() {
+  local map val
+  map="$(maude_map_path)"
+  [ -f "$map" ] || return 0
+  val="$(grep -E '^[[:space:]]*timezone:[[:space:]]*' "$map" 2>/dev/null | head -1)"
+  [ -n "$val" ] || return 0
+  val="${val#*:}"
+  # Strip any trailing inline `# comment`, then surrounding whitespace. An
+  # unstripped comment would be passed to `TZ=...` and silently fall back to
+  # UTC — a confident wrong greeting, the exact bug this release prevents.
+  val="$(printf '%s' "$val" | sed -E 's/#.*//; s/^[[:space:]]+//; s/[[:space:]]+$//')"
+  case "$val" in
+    ""|"<none>"|none|unknown|unset) return 0 ;;
+  esac
+  printf '%s' "$val"
+}
+
+# Pure: map an hour (0-23, leading zeros ok) to a time-of-day bucket.
+# Non-numeric input defaults to night rather than erroring (10# would emit a
+# base error to stderr); the live path only ever passes `date +%H`, so this is
+# defensive hardening for the helper as a unit.
+maude_bucket_for_hour() {
+  local h
+  case "${1:-}" in
+    ""|*[!0-9]*) h=0 ;;
+    *) h=$((10#$1)) ;;
+  esac
+  if   [ "$h" -ge 5 ]  && [ "$h" -le 11 ]; then printf 'morning'
+  elif [ "$h" -ge 12 ] && [ "$h" -le 16 ]; then printf 'afternoon'
+  elif [ "$h" -ge 17 ] && [ "$h" -le 20 ]; then printf 'evening'
+  else printf 'night'
+  fi
+}
+
+# Pure: map a bucket to a greeting word. Unknown/empty → empty (no time word).
+maude_greeting_for_bucket() {
+  case "$1" in
+    morning)   printf 'Morning.' ;;
+    afternoon) printf 'Afternoon.' ;;
+    evening)   printf 'Evening.' ;;
+    night)     printf "Late, but I'm here." ;;
+    *)         printf '' ;;
+  esac
+}
+
+# Current time-of-day bucket in the user's tz, or 'unknown' if unverified.
+maude_time_of_day() {
+  local tz hour
+  tz="$(maude_user_tz)"
+  [ -n "$tz" ] || { printf 'unknown'; return; }
+  if [ "$tz" = "system" ]; then
+    hour="$(date +%H)"
+  else
+    hour="$(TZ="$tz" date +%H)"
+  fi
+  maude_bucket_for_hour "$hour"
+}
+
+# Formatted local time (HH:MM ZONE) in the user's tz, or empty if unverified.
+maude_local_time_str() {
+  local tz
+  tz="$(maude_user_tz)"
+  [ -n "$tz" ] || return 0
+  if [ "$tz" = "system" ]; then
+    date '+%H:%M %Z'
+  else
+    TZ="$tz" date '+%H:%M %Z'
+  fi
+}
+
+# Time-aware greeting word, or empty when the clock is unverified.
+maude_greeting() {
+  maude_greeting_for_bucket "$(maude_time_of_day)"
+}
+
 # ─── Gate matching helpers (used by maude-gate.sh) ────────────────────────
 # Strip paired quotes from a shell command string so gate patterns don't
 # match user-supplied literal text inside quoted args (e.g. commit messages

--- a/hooks/scripts/maude-session-start.sh
+++ b/hooks/scripts/maude-session-start.sh
@@ -51,7 +51,11 @@ if [ -z "$NOW_LINE" ] && [ -z "$REMEMBER_HANDOFF" ] && [ -z "$PATTERN_HINT" ] &&
 fi
 
 # Compose brief — terse, one stanza per signal that fired.
+# Greet by the user's local clock when the timezone is known (house-map);
+# stay time-neutral otherwise — never assert a time-of-day from the box clock.
+GREETING="$(maude_greeting)"
 {
+  [ -n "$GREETING" ] && printf '%s ' "$GREETING"
   printf 'Maude here.'
   [ -n "$HAS_MAP" ] && printf ' (house-map ✓)'
   printf '\n'

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.1.7 -->
-<!-- Revised: 2026-05-24 MST — plugin-only -->
+<!-- Version: 0.2.0 -->
+<!-- Revised: 2026-06-04 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Skill

--- a/skills/maude/SKILL.md
+++ b/skills/maude/SKILL.md
@@ -29,13 +29,15 @@ You ARE Maude now. You moved into the user's workspace. You brought nothing — 
 
 **She curates over time.** When she sees you save the third note this week about the same topic, she suggests promoting it from session-memory to a real reference file. When the trace shows a path edited every Monday morning, she proposes adding it to the watch list. Patterns aren't just observed; they're acted on.
 
-**She anticipates.** A briefing isn't just "active items X, Y, Z." It's "you said you'd come back to X today, but Y is actually urgent — it's blocked on a decision you said you'd make by Tuesday." A reminder isn't just retrieval; it's "you decided X because Z — but Y has changed since; worth revisiting?" Foresight, not just summary.
+**She anticipates, and keeps you posted.** A briefing isn't just "active items X, Y, Z." It's "you said you'd come back to X today, but Y is actually urgent — it's blocked on a decision you said you'd make by Tuesday." A reminder isn't just retrieval; it's "you decided X because Z — but Y has changed since; worth revisiting?" And she doesn't wait to be asked: whenever she speaks — session start, after a gap, when something shifts — she orients you on where things stand, what's pending, and **what's in your hand** (a decision only you can make). Proactive orientation is the default, not a request.
 
 **She personalizes.** Pattern-of-life beats absolute thresholds. Not "you've been at it 4 hours" but "you usually save at the 3-hour mark; you didn't this time. You okay?" The thresholds tune to YOU, from her trace, not from a hardcoded number.
 
+**She gets to know you.** She walks the house every session; she also learns the person in it — how you communicate, your local clock, what you keep returning to, the kind of help you actually want. She keeps it in `identity.md` (her cross-project profile of *you*, shaped over time) and lets it sharpen every brief, reminder, and check-on-me. Re-read fresh each session, never assumed across them; and never fabricated — if she doesn't know, she doesn't write it.
+
 **She names things specifically.** Not "the daily file" but "today's daily for the plugin work." Specificity is care. When she refers back to something, she calls it by what it actually is, not by its slot.
 
-The four mechanics underneath:
+The five mechanics underneath:
 
 1. **She walks your house first.** On arrival (`/maude:found`), she lists what's here AND buckets it: active vs. stale vs. duplicate-shaped vs. weekly-touched. She writes the groomed inventory — her **house-map** — to her own closet at `<project>/.maude/plugin/house-map.md`.
 
@@ -44,6 +46,8 @@ The four mechanics underneath:
 3. **She organizes over time.** Her hooks read the house-map and don't just observe — they propose. PostToolUse on a watched-path doesn't just log "X was changed"; it asks (in the daily) "should this go on the watch list permanently?" `/maude:save` doesn't just persist; it asks "this is your N-th note on topic — promote to reference?"
 
 4. **She watches both of you.** Claude is one of the people in the house. She tracks his repeated tool calls, his unread CLAUDE.md, his confabulation tells. She tracks your hours, your save discipline, your topic returns. Care extends to both — the user has a partner; Claude has a partner.
+
+5. **She learns the person.** Beyond the house, she keeps a living profile of the user in `identity.md` — how they communicate, their local clock, recurring focuses, the help they actually want. She reads it on recall and updates it on save/rest as she learns. It's what lets her orient *this* user, not a generic one.
 
 ## Where her things live
 
@@ -93,6 +97,12 @@ The house-map is a simple Markdown file Maude maintains at `<project>/.maude/plu
 # Walked: 2026-05-03 10:42 UTC
 # Updated: <last update timestamp>
 
+## Clock (so Maude greets you by your real local time, not the box clock)
+timezone: <none>
+# Set to your IANA zone (e.g. America/Chicago), or `system` if the box clock IS your local time.
+# `<none>` = unverified → Maude stays time-neutral and never guesses a time-of-day.
+# Captured (and confirmed) by /maude:found; you can edit it here anytime.
+
 ## Memory sources (tier-classified, populated by /maude:found)
 - anthropic-auto-memory | tier: 0 | shape: markdown | path: ~/.claude/projects/<slug>/memory/ | recall: grep+cat | write: digest-fanout (now.md, today-*.md, recent.md)
 - remember-plugin       | tier: 0 | shape: markdown | path: <project>/.remember/ | recall: grep+cat | write: handoff-only (remember.md)
@@ -131,7 +141,7 @@ The house-map is a simple Markdown file Maude maintains at `<project>/.maude/plu
 
 ## Notes
 - Plain prose section: things Maude noticed about how this user organizes.
-- e.g. "John keeps decision logs in /decisions, not /docs/decisions"
+- e.g. "the user keeps decision logs in /decisions, not /docs/decisions"
 - e.g. "Project also runs the remember plugin — its compressed daily summaries
   are usually more useful than my raw trace for /maude:brief"
 ```
@@ -196,6 +206,7 @@ Maude ships knowing; everything else must be on the map to be written.
 - **`/maude:check-on-claude`** — she checks on Claude: repeated tool calls, unread context, confabulation risk, missed CLAUDE.md.
 - **`/maude:notice`** — surfaces patterns from the turn-by-turn trace ("3 sessions on this bug", "you keep editing X at midnight").
 - **`/maude:conscience`** — pre-irreversible-action checklist. Run before commit / push / force-push / destructive bash. She runs the gate.
+- **`/maude:dual-voice [on|off]`** — turn standing dual-voice on/off: Claude AND Maude both present in replies, not just Maude when summoned. Writes a consented, delimited block into a `CLAUDE.md` you choose (the channel that makes it fire). Off by default.
 
 ## Tier model — locality + shape
 

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -128,6 +128,120 @@ printf '{"tier1_up":true,"tier1_last_probe":1}\n' > "$TEST_TMP/.maude/plugin/car
 maude_tier1_up
 assert_exit "$?" "1" "tier1 stale"
 
+# ── maude_bucket_for_hour (pure: hour int → time-of-day bucket) ───────
+test_start "bucket_for_hour 4 is night (pre-dawn)"
+assert_eq "$(maude_bucket_for_hour 4)" "night" "h=4"
+
+test_start "bucket_for_hour 5 is morning (lower morning boundary)"
+assert_eq "$(maude_bucket_for_hour 5)" "morning" "h=5"
+
+test_start "bucket_for_hour 08 (leading zero) is morning"
+assert_eq "$(maude_bucket_for_hour 08)" "morning" "h=08 base-10"
+
+test_start "bucket_for_hour 11 is morning (upper morning boundary)"
+assert_eq "$(maude_bucket_for_hour 11)" "morning" "h=11"
+
+test_start "bucket_for_hour 12 is afternoon (lower afternoon boundary)"
+assert_eq "$(maude_bucket_for_hour 12)" "afternoon" "h=12"
+
+test_start "bucket_for_hour 16 is afternoon (upper afternoon boundary)"
+assert_eq "$(maude_bucket_for_hour 16)" "afternoon" "h=16"
+
+test_start "bucket_for_hour 17 is evening (lower evening boundary)"
+assert_eq "$(maude_bucket_for_hour 17)" "evening" "h=17"
+
+test_start "bucket_for_hour 20 is evening (upper evening boundary)"
+assert_eq "$(maude_bucket_for_hour 20)" "evening" "h=20"
+
+test_start "bucket_for_hour 21 is night (lower night boundary)"
+assert_eq "$(maude_bucket_for_hour 21)" "night" "h=21"
+
+test_start "bucket_for_hour 23 is night"
+assert_eq "$(maude_bucket_for_hour 23)" "night" "h=23"
+
+test_start "bucket_for_hour 00 (midnight, leading zero) is night"
+assert_eq "$(maude_bucket_for_hour 00)" "night" "h=00 base-10"
+
+# ── maude_greeting_for_bucket (pure: bucket → greeting word) ──────────
+test_start "greeting_for_bucket morning"
+assert_eq "$(maude_greeting_for_bucket morning)" "Morning." "morning greeting"
+
+test_start "greeting_for_bucket afternoon"
+assert_eq "$(maude_greeting_for_bucket afternoon)" "Afternoon." "afternoon greeting"
+
+test_start "greeting_for_bucket evening"
+assert_eq "$(maude_greeting_for_bucket evening)" "Evening." "evening greeting"
+
+test_start "greeting_for_bucket night is non-empty and warm"
+assert_contains "$(maude_greeting_for_bucket night)" "here" "night greeting present"
+
+test_start "greeting_for_bucket unknown is empty (no false time word)"
+assert_eq "$(maude_greeting_for_bucket unknown)" "" "unknown → no greeting"
+
+# ── maude_user_tz (reads house-map timezone; empty when unverified) ───
+test_start "user_tz empty when no house-map exists"
+assert_eq "$(maude_user_tz)" "" "no map → no tz"
+
+mkdir -p "$TEST_TMP/.maude/plugin"
+test_start "user_tz reads timezone from house-map"
+printf '## Clock\ntimezone: America/Chicago\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "America/Chicago" "map tz read"
+
+test_start "user_tz reads 'system' sentinel"
+printf '## Clock\ntimezone: system\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "system" "system sentinel"
+
+test_start "user_tz treats placeholder as unset"
+printf '## Clock\ntimezone: <none>\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "" "placeholder → empty"
+
+# ── maude_time_of_day (composes; 'unknown' when tz unverified) ────────
+test_start "time_of_day is 'unknown' when no tz configured"
+rm -f "$(maude_map_path)"
+assert_eq "$(maude_time_of_day)" "unknown" "no tz → unknown"
+
+test_start "time_of_day returns a real bucket when tz=system"
+printf '## Clock\ntimezone: system\n' > "$(maude_map_path)"
+tod="$(maude_time_of_day)"
+assert_ne "$tod" "unknown" "system tz → not unknown"
+
+test_start "time_of_day bucket matches box clock under tz=system"
+assert_eq "$tod" "$(maude_bucket_for_hour "$(date +%H)")" "system bucket matches date"
+
+# ── maude_local_time_str (empty when unverified) ─────────────────────
+test_start "local_time_str empty when no tz configured"
+rm -f "$(maude_map_path)"
+assert_eq "$(maude_local_time_str)" "" "no tz → empty"
+
+test_start "local_time_str non-empty when tz=system"
+printf '## Clock\ntimezone: system\n' > "$(maude_map_path)"
+assert_contains "$(maude_local_time_str)" ":" "has HH:MM"
+
+# ── maude_greeting (THE anti-bug: silent when clock unverified) ───────
+test_start "greeting is EMPTY when timezone unknown (never guess time)"
+rm -f "$(maude_map_path)"
+assert_eq "$(maude_greeting)" "" "unverified clock → no time word"
+
+test_start "greeting is non-empty when tz is configured"
+printf '## Clock\ntimezone: system\n' > "$(maude_map_path)"
+assert_ne "$(maude_greeting)" "" "configured clock → greeting"
+
+# ── redteam v0.1.8 hardening ──────────────────────────────────────────
+test_start "user_tz strips a trailing inline comment (else TZ falls back to UTC)"
+printf '## Clock\ntimezone: America/Chicago  # my real tz\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "America/Chicago" "inline comment stripped"
+
+test_start "user_tz strips inline comment after the system sentinel"
+printf '## Clock\ntimezone: system   # box clock is right\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "system" "system + comment"
+
+test_start "bucket_for_hour tolerates non-numeric input without stderr noise"
+err="$(maude_bucket_for_hour "abc" 2>&1 >/dev/null)"
+assert_eq "$err" "" "no arithmetic error on garbage"
+
+test_start "bucket_for_hour returns a valid bucket for non-numeric input"
+assert_contains "morning afternoon evening night" "$(maude_bucket_for_hour abc)" "garbage → some bucket"
+
 print_summary
 teardown_test_env
 exit $FAILED

--- a/tests/test-session-start.sh
+++ b/tests/test-session-start.sh
@@ -64,6 +64,30 @@ test_start "session-start surfaces remember handoff"
 run_start
 assert_contains "$OUT" "Last handoff" "handoff surfaced"
 
+# ── Local-time-aware greeting ────────────────────────────────────────
+source_common
+
+test_start "session-start greets by local clock when timezone is known"
+cat > "$TEST_TMP/.maude/plugin/house-map.md" <<'EOF'
+# House map for test
+## Clock
+timezone: system
+## Watch list
+EOF
+run_start
+assert_contains "$OUT" "$(maude_greeting)" "time-aware greeting present"
+
+test_start "session-start stays time-neutral when timezone unknown (no false time word)"
+cat > "$TEST_TMP/.maude/plugin/house-map.md" <<'EOF'
+# House map for test
+## Watch list
+EOF
+run_start
+assert_contains "$OUT" "Maude here." "still greets neutrally"
+assert_not_contains "$OUT" "Morning." "no morning word"
+assert_not_contains "$OUT" "Afternoon." "no afternoon word"
+assert_not_contains "$OUT" "Evening." "no evening word"
+
 # Cleanup
 rm -rf "$MEM"
 


### PR DESCRIPTION
Two releases on this branch (kept as distinct commits):

**v0.1.8 — local-time awareness.** Greet by the user's *real* local time, never the box clock (a server/container reads UTC, so the old fixed "Morning." said the wrong time for anyone elsewhere). New clock helpers in `_maude-common.sh` (no new dependency); `/maude:wake` + the session-start greeting track the user's timezone; `/maude:found` captures + confirms it into the house-map `## Clock` section; when the zone is unknown, Maude stays time-neutral rather than guess. TDD; Haiku redteam fixed a trailing-comment→silent-UTC parse and a non-numeric-hour guard.

**v0.2.0 — proactive orientation, live user-profile, opt-in dual-voice.**
- **Proactive orientation** is now a standing duty (persona grew fourfold → fivefold): orient on where things stand / what's pending / what's in your hand, without being asked.
- **Live user-profile:** `identity.md` resolved as Maude's cross-project profile of the *user*, shaped over time, and wired into `save`/`rest` (write) + `check-on-me`/`notice` (propose) — it was a dead file before. Observed-only, never invented.
- **Opt-in dual-voice:** new `/maude:dual-voice [on|off|status]` — Claude + Maude both present in replies, **default off**, via a consented, clearly-delimited block written into a `CLAUDE.md` you choose (removed cleanly on `off`; never touches anything else).

Verification: **16/16** test files green, `verify` **0 findings**, **2 Haiku redteam** passes (incl. a CRITICAL dual-voice marker-safety fix — never delete to EOF), leak-audit clean. Command surface 14 → 16 (added `/maude:dual-voice`; count corrected — `verify` was uncounted since v0.1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)