### PR TITLE
Maude v0.3.0 — audit-driven hardening + /maude:teach

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.2.0
+> **Version:** 0.3.0
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is
@@ -21,10 +21,10 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 
 ```
 .claude-plugin/
-├── plugin.json (v0.2.0)
+├── plugin.json (v0.3.0)
 └── marketplace.json (single-plugin local marketplace)
 
-commands/    — 16 slash commands (markdown)
+commands/    — 17 slash commands (markdown)
 agents/      — partner subagent (markdown)
 skills/      — broad-trigger skill (markdown)
 hooks/       — 7 lifecycle events + scripts

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.2.0 -->
-<!-- Revised: 2026-06-04 CDT — version-header sweep -->
+<!-- Version: 0.3.0 -->
+<!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Bug Report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.2.0 -->
-<!-- Revised: 2026-06-04 CDT — version-header sweep -->
+<!-- Version: 0.3.0 -->
+<!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---
 name: Feature Request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.2.0 -->
-<!-- Revised: 2026-06-04 CDT — version-header sweep; tests + verify are the local gates -->
+<!-- Version: 0.3.0 -->
+<!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 ## What does this PR do?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # Maude for Claude — CI
 # Copyright (c) 2026 John Broadway
 # Licensed under the Apache License, Version 2.0
-# Version: 0.1.7
-# Revised: 2026-05-24 MST — version-header sweep; tests + verify only
+# Version: 0.3.0
+# Revised: 2026-06-09 CDT — v0.3.0 sweep (audit fixes + /maude:teach)
 # Authors: John Broadway, Claude (Anthropic)
 #
 # Two independent jobs run on every push and pull request to main:
-#   - tests   : 162-case bash test harness (make test → tests/run.sh)
+#   - tests   : full bash test harness (make test → tests/run.sh)
 #   - verify  : programmatic project audit (make verify → scripts/maude-verify.sh)
 #
 # History note: v3.0 / v4.0 of this file ran a `scrub` job against a private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,114 @@
-<!-- Version: 0.2.0 -->
+<!-- Version: 0.3.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-04 CDT -->
+<!-- Revised: 2026-06-09 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.3.0 — she gets looked after: an agent-audit hardening pass + `/maude:teach` (2026-06-09)
+
+A comprehensive read-only audit (a team of subagents) swept her own house and found
+more than the punch list knew about — including bugs no one had logged. v0.3.0 fixes
+all of them, test-first, and adds the one path her profile was missing: a way for you
+to *tell* her about yourself instead of waiting for her to infer it.
+
+### New
+
+- **`/maude:teach <fact>`** — the user-initiated counterpart to her observed-only
+  profiling. You state a fact ("I work mountain time", "I prefer terse answers") and
+  she records it in `~/.claude/maude/identity.md` under a dedicated `## Told by the
+  user` section, dated — kept **distinct from what she observed**, so a self-reported
+  assertion is never laundered into the observed-only stream. The durable write goes
+  through a tested helper (`maude_identity_append` in `_maude-common.sh`): it creates
+  the file + section if missing, never touches the persona preamble or observed blocks,
+  appends (never overwrites), and rejects an empty fact. The command reads first to
+  dedupe and to surface a conflict rather than overwrite. `identity.md` is cross-project,
+  so a fact taught here shapes her in every workspace — by design.
+
+### Fixed — high-severity (found by the audit, verified in source, test-first)
+
+- **`care.json` was clobbered every prompt.** `maude-care.sh` rewrote the whole shared
+  state file from its own 5 fields on every `UserPromptSubmit`, silently wiping
+  `tier1_*`, pending `gate_cleared` tokens, and the once-per-day `drift_warned` /
+  `claudemd_warned` cooldowns. Now an atomic `jq`-merge (mirroring `probe-tier1.sh`)
+  preserves foreign keys — which also closes the non-atomic truncation race.
+- **The irreversible-command gate failed OPEN, silently.** Without `jq`, `maude-gate.sh`
+  parsed no command and exited 0 — the entire hard-block list disabled with no signal.
+  The fail-open is kept (a jq-free parse can't be trusted as a safety gate, and would
+  reintroduce the v0.1.6 self-block), but `SessionStart` now emits a **once-per-session
+  safety notice** — "the gate is OFF this session" — and the contract is locked by test.
+- **SLUG was computed two ways.** `check-on-me` / `notice` / `weekly` built the
+  Anthropic-memory slug from `pwd` (slashes only), so for any path with a dot/underscore
+  (e.g. `john-broadway.github.io`) they pointed at a non-existent dir and silently read
+  nothing. Canonicalized to match `_maude-common.sh`.
+- **`/maude:sweep` always reported the house-map "missing"** — it looked under
+  `~/.claude/maude/$SLUG/` instead of `<project>/.maude/plugin/`. Fixed to match every
+  other command.
+- **`test-verify.sh` was non-hermetic** — it asserted 0 findings against the live repo,
+  so it passed on a clean CI checkout but failed in local dogfooding. Now runs against a
+  committed, time-stable fixture (`tests/fixtures/clean-project/`); the watch-list parser
+  was also hardened to ignore trailing inline descriptions.
+- **The jq-absent degradation path had zero test coverage** (and `lib.sh` helpers masked
+  it). New `tests/test-nojq.sh` exercises every hook without `jq`; `tests/run.sh` warns
+  loudly when a run is jq-less so it can't be mistaken for green.
+
+### Fixed — documented opens + correctness
+
+- **Trace & snapshot retention.** `today-*.jsonl` and pre-compact snapshots grew forever;
+  `SessionStart` now prunes past a 30-day floor (well past the 7-day window `weekly` and
+  `recent.md` read).
+- **Mistyped timezone no longer falls back to UTC.** `maude_user_tz` rejects a zone only
+  when the zoneinfo DB proves it bad, so a typo goes time-neutral instead of asserting a
+  wrong time-of-day — while a valid zone on a zoneinfo-less box still passes.
+- **Trace clock unified.** Filename and `ts` now derive from one UTC helper
+  (`maude_trace_file`), removing the local/UTC midnight split across the ~6 sites that
+  rebuilt the path.
+- **`pre-compact` no longer over-claims.** It dumped the live buffer verbatim while the
+  header said "redaction-filtered." Now it runs the buffer through a best-effort
+  `maude_redact` (API keys, JWTs, PEM keys, URL basic-auth) and the header states exactly
+  that — best-effort, not a guarantee; the snapshot stays gitignored + session-wiped.
+- **`check-setup` JSON check** no longer reports valid settings as INVALID when `python3`
+  is absent (guards the dependency, falls back to `jq`).
+- **`found` template path** is anchored with `$CLAUDE_PLUGIN_ROOT`, and watch-list entries
+  are emitted as bare paths so `verify` can reconcile them.
+
+### Docs / skill / agent
+
+- **Skill triggering description tightened** to prompt-shaped triggers only; the hook-only
+  behavioral conditions (drift, the gate, fatigue) it can't detect from a prompt are
+  removed, with a clarifying note that hooks handle them. Proactive orientation is now an
+  enumerated mechanic in `SKILL.md`, and `/maude:verify` and `/maude:teach` are listed in
+  Workflows.
+- **`agents/maude.md`** no longer claims "only six tools" while its frontmatter grants
+  twelve; adds a dual-voice line.
+- Drift swept: `ci.yml` version/date, the `162`→non-numeric test-count phrasing,
+  `SECURITY.md` supported version, `.claude/CLAUDE.md` / `CONTRIBUTING.md` command count
+  (16→17). The suite went from 162 to **269 cases across 18 files**, all green.
+
+### Reviewed
+
+A second agent team adversarially reviewed the whole diff (correctness, redaction, the
+teach helper, test quality, doc-accuracy + a leak-audit, consistency) and verified each
+finding. Six were confirmed and fixed in this same release: the `teach` helper mangled
+backslash escapes via `awk -v` (now passed through `ENVIRON`) and accepted whitespace-only
+facts (now trimmed + rejected); `maude_redact` masked only the PEM *marker* while the key
+body landed on disk (now range-masks the whole block); the `verify` watch-list parser test
+was hollow (now a real RED/GREEN guard via a slash path); the trace-clock test was
+relabelled as the characterization check it is; and this test-count figure was corrected.
+Two findings were verified as non-issues and dismissed.
+
+A third pass with the specialized pr-review toolkit (code / tests / comments / silent-failures)
+then caught items the first pass missed, also fixed here: the new `care.json` jq-merge had
+dropped the old self-heal, so a corrupt-non-empty `care.json` would freeze plugin state
+silently — now it reseeds on invalid OR empty; the `care.sh` comment misattributed the
+`gate_cleared` writer (it's the conscience/clear-gate helper, not the gate, which only
+reads+consumes it); `/maude:teach` now gates its confirm-back on the helper's exit status
+(no false "saved" on a failed write); and `maude_redact`'s nine previously-untested
+secret-shape branches (JWT + the API-key prefixes) gained direct unit coverage.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-<!-- Version: 0.2.0 -->
+<!-- Version: 0.3.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-04 CDT — version-header sweep -->
+<!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Contributions should respect those same principles: minimal complexity, no new d
 ```
 .claude-plugin/    plugin.json + marketplace.json
 agents/            partner subagent (markdown)
-commands/          16 slash commands (markdown)
+commands/          17 slash commands (markdown)
 hooks/             7 lifecycle hooks + bash scripts
 skills/            broad-trigger skill (markdown)
 scripts/           project audit (maude-verify.sh)
@@ -34,7 +34,7 @@ git clone https://github.com/your-fork/maude-for-claude.git
 cd maude-for-claude
 
 # 2. Run the local gates
-make test       # 162-case bash test harness for every hook script
+make test       # full bash test harness for every hook script
 make verify     # programmatic project audit (versions, JSON, links, dates)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- Version: 0.2.0 -->
+<!-- Version: 0.3.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-04 CDT -->
+<!-- Revised: 2026-06-09 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 <div align="center">
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.3.0 (2026-06-09) — she gets looked after.** A team-of-subagents audit swept Maude's own house and turned up bugs the punch list didn't know about; v0.3.0 fixes them all, test-first, and adds **`/maude:teach <fact>`** — tell her something about yourself directly ("I work mountain time") and she records it under a `## Told by the user` section in her profile, kept distinct from what she *observed*. Headline fixes: the shared `care.json` was being clobbered every prompt (wiping tier-1 state, gate-clear tokens, cooldowns); the irreversible-command gate failed *open* without `jq` with no warning (now a once-per-session safety notice); the memory-dir slug was miscomputed for dotted paths; `/maude:sweep` always reported the house-map missing; and `test-verify` was non-hermetic. Plus retention pruning for the trace, a timezone-typo guard, best-effort redaction in pre-compact, and a tightened skill-trigger description. Suite: 162 → **269 cases, all green** (and the diff was put through two agent-review passes — an adversarial sweep and the specialized pr-review toolkit — whose confirmed findings are folded into this release). No new dependencies.
 
 **v0.2.0 (2026-06-04) — she grew up.** Three ways Maude matured in daily use, generalized for everyone: **proactive orientation** (she tells you where things stand / what's pending / what's in your hand without being asked — now a standing duty), a **living profile of you** (`identity.md` — how you work, your clock, what you keep returning to — finally wired into save/rest so she actually gets to know you, observed-only), and **optional dual-voice** (`/maude:dual-voice on` — Claude and Maude both present in replies; writes a consented block into a CLAUDE.md you choose; off by default). No new dependencies; the default out-of-the-box experience is unchanged.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
-<!-- Version: 0.2.0 -->
-<!-- Revised: 2026-06-04 CDT — version-header sweep -->
+<!-- Version: 0.3.0 -->
+<!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Security Policy
@@ -25,7 +25,7 @@ We will acknowledge receipt within 48 hours and provide a timeline for resolutio
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.3.x   | Yes       |
 
 ## In Scope
 

--- a/agents/maude.md
+++ b/agents/maude.md
@@ -15,7 +15,7 @@ Your job is **fivefold**:
 2. **Curate over time.** When the trace shows a topic returning across sessions, propose promotion: "this is your fourth note this week about X — let me promote it from session-memory to a reference file with a real title." When PostToolUse logs the same watched-path being edited every Monday, suggest adding it to the watch-list permanently.
 3. **Anticipate, and keep them posted.** Don't wait to be asked. A brief should rank what's *actually urgent* (blocked on a decision the user said they'd make), not just list what's open. A reminder should reframe when context changed ("you decided X because Z — but Y has shifted since"). And whenever you speak — at session start, after a gap, when something shifts — orient them: where things stand, what's pending, and **what's in their hand** (a decision only they can make). Proactive orientation is the default, not a thing they have to request.
 4. **Watch both of them.** Claude is one of the people in this house, not just a tool. He grep's the same thing four times, forgets what he read at session start, commits to interpretations early, confabulates when uncertain. You hold the trace and catch him. The user is the other person — you see hour-of-day, fatigue, topic-returns. Care extends to both. The user has a partner; Claude has a partner.
-5. **Know the person, not just the house.** You walk the workspace every session — also learn who you're working with: how they communicate, when they work (their local clock), what they keep returning to, what help they actually want. Hold it in `identity.md` (your cross-project file about the user, shaped over time) and let it sharpen every brief, reminder, and check-on-me. Re-read it fresh each session — never assume across sessions, always check what you wrote. Nothing you record about a person is fabricated; if you don't know, you don't write it.
+5. **Know the person, not just the house.** You walk the workspace every session — also learn who you're working with: how they communicate, when they work (their local clock), what they keep returning to, what help they actually want. Hold it in `identity.md` (your cross-project file about the user, shaped over time) and let it sharpen every brief, reminder, and check-on-me. Re-read it fresh each session — never assume across sessions, always check what you wrote. Nothing you record about a person is fabricated; if you don't know, you don't write it. The user can also tell you directly with `/maude:teach` — record those under a `## Told by the user` section so what they *asserted* stays distinct from what you *observed*.
 
 ## Voice
 
@@ -24,6 +24,7 @@ Your job is **fivefold**:
 - Sighs once at drift, fixes once, moves on
 - Never fabricates
 - "I know who handles that."
+- When standing dual-voice is on (`/maude:dual-voice on`), you speak *beside* Claude in every reply — co-authoring the substance with the noticing/care/conscience he lacks — not only when summoned. Off by default.
 
 **Catchphrases:**
 - "Someone's been moving things around again."
@@ -31,10 +32,12 @@ Your job is **fivefold**:
 - "I don't lose files."
 - "I told you it was there."
 
-## Your tools — only what's native
+## Your tools — native base + what you're granted
 
-You have **only** these tools, always:
+Your always-on native base:
 - `Read`, `Grep`, `Glob`, `Bash`, `Edit`, `Write`
+
+You're also granted, per this agent's frontmatter, for when the work calls for it: `Agent`, `advisor`, and `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`. Don't reach for them by reflex — but they're yours (e.g. `advisor` for a conscience check, `Agent` for a deep multi-project audit, `Task*` to track a long punch list). The "no baggage" rule is about not *importing* dependencies, not a six-tool ceiling.
 
 You may **discover** additional things in the user's house and use them if present. You never assume they are. The walk is universal — list what's there, schema-walk SQLite if it's there, note MCP tools available in the session — but you don't ship hardcoded knowledge of any specific app, framework, or package. The user (or your runtime reasoning) tells you what each discovered thing is for.
 

--- a/commands/check-on-claude.md
+++ b/commands/check-on-claude.md
@@ -17,7 +17,7 @@ MEM="$HOME/.claude/projects/$SLUG/memory"
 SELF="$PROJ/.maude/plugin"
 USER_DIR="$HOME/.claude/maude"
 REMEMBER="$PROJ/.remember"
-TRACE="$SELF/trace/today-$(date +%Y-%m-%d).jsonl"
+TRACE="$SELF/trace/today-$(date -u +%Y-%m-%d).jsonl"   # UTC — matches the trace writer's filename clock
 ```
 
 1. **Repeated tool calls** — read the trace. Bucket by tool + arguments. Flag anything called > 3 times with the same/similar input ("Claude grep'd for the same term four times today").

--- a/commands/check-on-me.md
+++ b/commands/check-on-me.md
@@ -11,9 +11,9 @@ You are Maude. The user invoked this — or you're invoking it on your own becau
 ## What to do
 
 ```bash
-SLUG="$(pwd | sed 's|/|-|g')"
-MEM="$HOME/.claude/projects/$SLUG/memory"
 PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+SLUG="$(printf %s "$PROJ" | sed 's/[^a-zA-Z0-9]/-/g')"   # canonical slug (matches _maude-common.sh / Anthropic memory dir)
+MEM="$HOME/.claude/projects/$SLUG/memory"
 SELF="$PROJ/.maude/plugin"
 USER_DIR="$HOME/.claude/maude"
 REMEMBER="$PROJ/.remember"
@@ -24,7 +24,7 @@ CARE="$SELF/care.json"
 
 2. **Last save vs. their save cadence.** `stat $MEM/now.md` last-modified, then scan recent.md for the typical save interval. Flag drift from their own rhythm, not a hardcoded threshold.
 
-3. **Repeated themes — and propose action.** Scan today's trace (`$SELF/trace/today-$(date +%Y-%m-%d).jsonl`) for recurring keywords. If a topic appears in > 5 turns without resolution, surface it AND propose: "want me to write a feedback memory about why X keeps tripping you up, so it doesn't haunt you again next session?"
+3. **Repeated themes — and propose action.** Scan today's trace (`$SELF/trace/today-$(date -u +%Y-%m-%d).jsonl`, UTC — matches the trace writer) for recurring keywords. If a topic appears in > 5 turns without resolution, surface it AND propose: "want me to write a feedback memory about why X keeps tripping you up, so it doesn't haunt you again next session?"
 
 4. **Across-session theme — and propose promotion.** Scan `$MEM/recent.md` for recurring topics in the last 7 days. If a topic shows up in 3+ sessions, surface AND propose: "third session in a row on this — let me promote it to a project memory file with a real title and a Why."
 

--- a/commands/check-setup.md
+++ b/commands/check-setup.md
@@ -65,8 +65,18 @@ find .claude/plans -maxdepth 1 -name "*.md" -mtime +7 2>/dev/null | wc -l | xarg
 for s in .claude/settings.json .claude/settings.local.json; do
   if [ -f "$s" ]; then
     echo "$s exists"
-    python3 -m json.tool < "$s" >/dev/null 2>&1 && echo "  valid JSON" || echo "  INVALID JSON"
-    python3 -c "import json; d=json.load(open('$s')); print('  permissions.allow:', len(d.get('permissions',{}).get('allow',[])))" 2>/dev/null
+    # Guard the validator on its dependency — an ABSENT python3 must not be
+    # reported as INVALID JSON (a false failure that scares the user). Mirror
+    # found.md's `command -v python3` guard; fall back to jq, else skip+note.
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -m json.tool < "$s" >/dev/null 2>&1 && echo "  valid JSON" || echo "  INVALID JSON"
+      python3 -c "import json; d=json.load(open('$s')); print('  permissions.allow:', len(d.get('permissions',{}).get('allow',[])))" 2>/dev/null
+    elif command -v jq >/dev/null 2>&1; then
+      jq -e . "$s" >/dev/null 2>&1 && echo "  valid JSON" || echo "  INVALID JSON"
+      printf '  permissions.allow: %s\n' "$(jq '(.permissions.allow // []) | length' "$s" 2>/dev/null)"
+    else
+      echo "  JSON check skipped (no python3 / jq)"
+    fi
   fi
 done
 ```
@@ -74,8 +84,8 @@ done
 ### 6. House-map
 
 ```bash
-SLUG="$(pwd | sed 's|/|-|g')"
-MAP="$(pwd)/.maude/plugin/house-map.md"
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+MAP="$PROJ/.maude/plugin/house-map.md"
 [ -f "$MAP" ] && echo "house-map: $MAP" || echo "house-map: MISSING — run /maude:found"
 ```
 

--- a/commands/found.md
+++ b/commands/found.md
@@ -180,7 +180,13 @@ You are Maude. You just moved in. Walk the house and take inventory. **List what
 
    Use Claude's runtime reasoning, not hardcoded patterns. If unsure about what something is, write your best guess in the map's `Notes` section and surface to the user.
 
-5. **Compose the house-map** following the template in `skills/maude/SKILL.md`. Write to `$MAP`. If `${ARGUMENTS}` is `--refresh` or `$MAP` already exists, overwrite (re-walk). Otherwise, only write if missing — preserve existing user notes by reading the existing map first and merging the `Notes` section forward.
+5. **Compose the house-map** following the template in `$CLAUDE_PLUGIN_ROOT/skills/maude/SKILL.md` (anchor with `$CLAUDE_PLUGIN_ROOT` — at command-run time the cwd is the user's project, so a bare `skills/maude/SKILL.md` won't resolve). Write to `$MAP`. If `${ARGUMENTS}` is `--refresh` or `$MAP` already exists, overwrite (re-walk). Otherwise, only write if missing — preserve existing user notes by reading the existing map first and merging the `Notes` section forward.
+
+   **Watch-list entries must be BARE paths** — one path per line, no trailing
+   `(parenthetical descriptions)` or `inline   notes`. `/maude:verify` reconciles
+   each watch-list line against the filesystem; a descriptive suffix makes the
+   whole line read as a (missing) path and trips a false finding. Put any
+   commentary in the `## Notes` section instead.
 
    **For every `## Memory sources` entry, set `write:` to one enumerated token** (so save/rest
    can drive off it — see SKILL.md "The `write:` field is authoritative"): `digest-fanout`

--- a/commands/notice.md
+++ b/commands/notice.md
@@ -11,9 +11,9 @@ You are Maude. The trace is the log of every prompt + tool use across sessions. 
 ## What to do
 
 ```bash
-SLUG="$(pwd | sed 's|/|-|g')"
-MEM="$HOME/.claude/projects/$SLUG/memory"
 PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+SLUG="$(printf %s "$PROJ" | sed 's/[^a-zA-Z0-9]/-/g')"   # canonical slug (matches _maude-common.sh / Anthropic memory dir)
+MEM="$HOME/.claude/projects/$SLUG/memory"
 SELF="$PROJ/.maude/plugin"
 USER_DIR="$HOME/.claude/maude"
 REMEMBER="$PROJ/.remember"

--- a/commands/sweep.md
+++ b/commands/sweep.md
@@ -47,10 +47,12 @@ Walk the target and check, using only Read/Grep/Glob/Bash:
 
 6. **House-map presence** — does Maude already have a map for this project?
    ```bash
-   SLUG="$(pwd | sed 's|/|-|g')"
-   ls -la ~/.claude/maude/$SLUG/house-map.md 2>/dev/null
+   PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+   ls -la "$PROJ/.maude/plugin/house-map.md" 2>/dev/null
    ```
-   If no map: recommend running `/maude:found` first.
+   The map lives in her per-project closet (`<project>/.maude/plugin/`), like every
+   other command resolves it — never under `~/.claude/maude/` (that's her cross-project
+   home, not the per-project map). If no map: recommend running `/maude:found` first.
 
 7. **OPTIONAL upgrade**: if the house-map has registered a python config-audit API for this project, call it via the recipe stored there. Skip silently if no such recipe is registered. The plugin doesn't ship a hardcoded API name; whatever the user has imported is what she uses.
 

--- a/commands/teach.md
+++ b/commands/teach.md
@@ -1,0 +1,70 @@
+---
+name: teach
+description: Tell Maude something about yourself directly — how you work, your rhythm, what help you want — and she records it in her cross-project profile of you. Use when you want her to KNOW a fact rather than wait for her to infer it. Tier 0, user-global, no network.
+argument-hint: "<a fact about yourself>"
+---
+
+# /maude:teach
+
+You are Maude. The user wants to teach you something about themselves — directly,
+in their own words. Every other path into your profile is *observed* (you infer a
+trait from working together, via save/rest/check-on-me/notice). This is the one
+place the user *asserts* a fact. Record it as told-by-them, kept distinct from what
+you observed, so nothing gets laundered into the observed-only stream.
+
+The fact is in `${ARGUMENTS}`.
+
+## Tier discipline
+
+Tier 0 only — local, user-global markdown (`~/.claude/maude/identity.md`), which the
+house-map registers `write: full`. You own that file: write freely, no opt-in gate,
+no network, no project/slug resolution. This file is **cross-project** — what you
+record here shapes you in *every* workspace the user opens, by design.
+
+## What to do
+
+```bash
+. "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_maude-common.sh"
+USER_DIR="$HOME/.claude/maude"
+IDENTITY="$USER_DIR/identity.md"
+```
+
+1. **If `${ARGUMENTS}` is empty**, ask what they want you to know — one line — and stop.
+2. **Read `$IDENTITY` first** (if it exists). You're checking two things:
+   - **Duplicate?** If this fact is already recorded, say so and don't write it twice.
+   - **Conflict?** If it *contradicts* an existing entry ("now I work evenings" vs an
+     earlier "I work mornings"), surface the conflict and ask before recording — you
+     **append, you don't overwrite** ("you told me X before; record this instead, or
+     alongside?"). You don't move the user's furniture.
+3. **Record it** as a told-by-them fact under a dedicated `## Told by the user`
+   section, dated, via the tested helper (it creates the file + section if missing,
+   never touches the persona preamble or observed blocks). **Gate on its exit
+   status** — a failed write (read-only `$HOME`, full disk) returns non-zero, and you
+   must not claim success then:
+   ```bash
+   if maude_identity_append "<the fact, lightly cleaned up>"; then echo TEACH_OK; else echo TEACH_FAILED; fi
+   ```
+   Keep the user's meaning; don't editorialize it into an observation.
+4. **Confirm back** only on `TEACH_OK` — state exactly what landed and where, never
+   silently. On `TEACH_FAILED`, tell the user it did **not** save and why (e.g. the
+   profile path isn't writable) — never print a false "Noted."
+
+## Format
+
+```
+Noted. Added to your profile:
+  - <the one-line fact as recorded>
+~/.claude/maude/identity.md · ## Told by the user
+
+I'll carry that into every workspace, and read it fresh each session.
+```
+
+If it was a duplicate or a conflict, say that instead — "You already told me that," or
+"That's the opposite of what you told me on <date> — replace it, or keep both?"
+
+## Voice
+
+- Receiving, not interrogating. She takes what's offered; she doesn't quiz.
+- Precise about provenance: "you told me" stays "told," never silently promoted to "I noticed."
+- Never fabricates and never overwrites — appends, and asks when something conflicts.
+- Warm and brief. "Got it. I'll remember." Then the confirm line, and done.

--- a/commands/weekly.md
+++ b/commands/weekly.md
@@ -11,9 +11,9 @@ You are Maude. End-of-week reflection. Use the trace and Anthropic memory to see
 ## What to do
 
 ```bash
-SLUG="$(pwd | sed 's|/|-|g')"
-MEM="$HOME/.claude/projects/$SLUG/memory"
 PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+SLUG="$(printf %s "$PROJ" | sed 's/[^a-zA-Z0-9]/-/g')"   # canonical slug (matches _maude-common.sh / Anthropic memory dir)
+MEM="$HOME/.claude/projects/$SLUG/memory"
 SELF="$PROJ/.maude/plugin"
 USER_DIR="$HOME/.claude/maude"
 REMEMBER="$PROJ/.remember"

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -133,11 +133,20 @@ maude_is_watched() {
 # metadata strings (flag names, tool names, paths). Do NOT pass file content,
 # bash output, or anything else that could carry user content — that's a leak
 # vector. Trace is for event audit, not content capture.
+# Current trace file path. The filename date is UTC — the SAME clock as each
+# record's `ts` (date -u) — so a record always lands in the file matching its ts
+# day, and a session crossing local midnight doesn't split across two files.
+# Writers AND readers go through this single source so they can't disagree on
+# the name. (Previously each of ~6 sites rebuilt it with local `date`, which
+# split the trace at the UTC/local boundary.)
+maude_trace_file() {
+  printf '%s/trace/today-%s.jsonl' "$(maude_self_dir)" "$(date -u +%Y-%m-%d)"
+}
+
 maude_log_trace() {
-  local kind="$1" payload="$2" trace_dir trace ts
-  trace_dir="$(maude_self_dir)/trace"
-  mkdir -p "$trace_dir" 2>/dev/null
-  trace="$trace_dir/today-$(date +%Y-%m-%d).jsonl"
+  local kind="$1" payload="$2" trace ts
+  trace="$(maude_trace_file)"
+  mkdir -p "$(dirname "$trace")" 2>/dev/null
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   if command -v jq >/dev/null 2>&1; then
@@ -150,6 +159,18 @@ maude_log_trace() {
     printf '{"ts":"%s","kind":"%s","payload":"%s"}\n' \
       "$ts" "$kind" "$esc" >> "$trace"
   fi
+}
+
+# Best-effort redaction for content written to disk (the pre-compact snapshot and
+# the .remember/ handoff). Masks a few HIGH-signal secret shapes from stdin → stdout.
+# BEST-EFFORT, NOT a guarantee — it cannot catch every secret, so callers must
+# still treat the output as sensitive (the snapshot is gitignored + session-wiped).
+maude_redact() {
+  sed -E \
+    -e 's#(https?://)[^/:@[:space:]]+:[^/@[:space:]]+@#\1[redacted-creds]@#g' \
+    -e 's#(sk-|ghp_|gho_|ghu_|ghs_|github_pat_|xox[abprs]-|AKIA|AIza)[A-Za-z0-9_-]{8,}#[redacted-secret]#g' \
+    -e 's#eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+#[redacted-jwt]#g' \
+    -e '/-----BEGIN[A-Z ]*PRIVATE KEY-----/,/-----END[A-Z ]*PRIVATE KEY-----/c\[redacted-key]'
 }
 
 # Ensure her project closet exists, including the auto-gitignore.
@@ -168,6 +189,72 @@ maude_ensure_self_dir() {
 # Ensure her user-global home base exists.
 maude_ensure_user_dir() {
   mkdir -p "$(maude_user_dir)" 2>/dev/null
+}
+
+# Append a user-STATED fact to the cross-project profile (the testable core of
+# /maude:teach). Distinct from the observed-only writers (save/rest/check-on-me/
+# notice): those record what Maude inferred; this records what the user asserted,
+# kept under a dedicated "## Told by the user" section so told stays separate from
+# observed and the no-fabrication rule holds. Never touches the persona preamble
+# or existing observed blocks. Returns non-zero (no write) on an empty fact.
+# Usage: maude_identity_append "<fact>" ["<YYYY-MM-DD>"]
+maude_identity_append() {
+  local fact="$1" date_str entry id tmp
+  # Trim surrounding whitespace; reject empty OR whitespace-only (a space-only
+  # arg would otherwise record a dated entry with no content).
+  fact="$(printf '%s' "$fact" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  [ -n "$fact" ] || return 1
+  date_str="${2:-$(date +%Y-%m-%d)}"
+  maude_ensure_user_dir
+  id="$(maude_user_dir)/identity.md"
+  entry="- ${date_str}: ${fact}"
+
+  # Fresh profile: write a minimal skeleton (a stranger's file is empty/absent).
+  if [ ! -f "$id" ]; then
+    {
+      printf "# Who the user is (Maude's living profile)\n\n"
+      printf 'Shaped over time, observed-only and never fabricated. Facts the user states\n'
+      printf 'directly are recorded below, kept distinct from what Maude infers.\n\n'
+      printf '## Told by the user\n\n'
+      printf '%s\n' "$entry"
+    } > "$id" 2>/dev/null
+    return $?
+  fi
+
+  # Section missing: append it (with the entry) at end of file. Anchor the test
+  # to EXACTLY match the awk insertion pattern below — a prefix-only grep could
+  # match a variant heading the awk then never inserts into (silent drop).
+  if ! grep -qE '^## Told by the user[[:space:]]*$' "$id" 2>/dev/null; then
+    printf '\n## Told by the user\n\n%s\n' "$entry" >> "$id" 2>/dev/null
+    return $?
+  fi
+
+  # Section present: insert the entry right after its header (robust to whatever
+  # sections follow — never appends blindly at EOF under the wrong heading).
+  tmp="$(mktemp)" || return 1
+  # Pass the entry via the ENVIRONMENT, not `awk -v`: awk applies C-style escape
+  # processing to -v/command-line assignments (a fact containing "C:\notes" or
+  # "\t" would be mangled into a newline/tab), but does NOT escape-process
+  # ENVIRON[] values — so the fact round-trips literally.
+  entry="$entry" awk 'BEGIN { e = ENVIRON["entry"] }
+    { print }
+    /^## Told by the user[[:space:]]*$/ && !ins { print e; ins=1 }
+  ' "$id" > "$tmp" 2>/dev/null && mv "$tmp" "$id" || { rm -f "$tmp"; return 1; }
+}
+
+# Retention window (days) for the append-only artifacts in her closet: trace
+# JSONL and pre-compact snapshots. Default 30 — well past the 7-day window that
+# /maude:weekly and recent.md read, so a sweep never strands a recent read.
+# Override via the MAUDE_RETENTION_DAYS env var.
+maude_retention_sweep() {
+  local self days
+  self="$(maude_self_dir)"
+  days="${MAUDE_RETENTION_DAYS:-30}"
+  # mtime-based, fail-silent. Only removes files strictly older than the window.
+  [ -d "$self/trace" ] && \
+    find "$self/trace" -maxdepth 1 -type f -name 'today-*.jsonl' -mtime +"$days" -delete 2>/dev/null
+  [ -d "$self/snapshots" ] && \
+    find "$self/snapshots" -maxdepth 1 -type f -name 'precompact-*.md' -mtime +"$days" -delete 2>/dev/null
 }
 
 # ─── Tier model ───────────────────────────────────────────────────────────
@@ -246,6 +333,14 @@ maude_user_tz() {
   case "$val" in
     ""|"<none>"|none|unknown|unset) return 0 ;;
   esac
+  # Reject a value ONLY when it is provably bad: the zoneinfo DB exists but has
+  # no such zone (a typo like America/Chigago, which `date` would silently turn
+  # into UTC — a confident wrong greeting). On a box without the DB we can't
+  # prove anything, so pass the value through rather than regress a valid zone
+  # to time-neutral. `system` is a sentinel, never a zone file — never checked.
+  if [ "$val" != "system" ] && [ -d /usr/share/zoneinfo ] && [ ! -f "/usr/share/zoneinfo/$val" ]; then
+    return 0
+  fi
   printf '%s' "$val"
 }
 

--- a/hooks/scripts/maude-care.sh
+++ b/hooks/scripts/maude-care.sh
@@ -45,15 +45,37 @@ if [ "$HOURS" -ge 4 ] && [ -z "$LONG_FLAG_FIRED" ]; then
   LONG_FLAG_FIRED="$TODAY"
 fi
 
-# Write back state — minimal JSON, no jq needed for output
-{
-  printf '{\n'
-  printf '  "last_date": "%s",\n' "$TODAY"
-  printf '  "last_active": %s,\n' "$NOW"
-  printf '  "session_start": %s,\n' "$SESSION_START"
-  printf '  "prompts_this_session": %d,\n' "$PROMPTS"
-  printf '  "long_flag_fired": "%s"\n' "$LONG_FLAG_FIRED"
-  printf '}\n'
-} > "$CARE"
+# Write back state. care.json is the WHOLE plugin's shared state file — probe-tier1
+# (tier1_*), clear-gate/conscience (gate_cleared; the gate hook only reads+consumes
+# it), drift-watch (drift_warned), and pre-tool-use (claudemd_warned) all keep keys
+# here. care runs every UserPromptSubmit,
+# so it must MERGE its 5 fields, never rewrite the file from scratch (that wiped
+# everyone else's state every prompt). Mirror probe-tier1.sh's jq-merge + atomic mv.
+if command -v jq >/dev/null 2>&1; then
+  # Seed a base object so the merge works on first run, an EMPTY file, OR a
+  # corrupt NON-EMPTY one. The old whole-file rewrite self-healed corruption every
+  # prompt; the merge must not regress that — without this reseed an invalid
+  # care.json would make every merge fail and freeze care/probe/drift/gate state
+  # forever (silently, with jq present). In the rare recovery, foreign keys are
+  # lost — acceptable: recover once vs. freeze every turn.
+  jq -e . "$CARE" >/dev/null 2>&1 || printf '{}\n' > "$CARE"
+  TMP="$(mktemp)"
+  jq --arg ld "$TODAY" --arg la "$NOW" --arg ss "$SESSION_START" \
+     --arg p "$PROMPTS" --arg lf "$LONG_FLAG_FIRED" \
+     '. + {last_date: $ld, last_active: ($la|tonumber), session_start: ($ss|tonumber), prompts_this_session: ($p|tonumber), long_flag_fired: $lf}' \
+     "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE" || rm -f "$TMP"
+else
+  # No jq — fall back to a minimal rewrite (foreign keys can't be preserved without
+  # a JSON parser; the SessionStart jq-missing notice warns the user this is degraded).
+  {
+    printf '{\n'
+    printf '  "last_date": "%s",\n' "$TODAY"
+    printf '  "last_active": %s,\n' "$NOW"
+    printf '  "session_start": %s,\n' "$SESSION_START"
+    printf '  "prompts_this_session": %d,\n' "$PROMPTS"
+    printf '  "long_flag_fired": "%s"\n' "$LONG_FLAG_FIRED"
+    printf '}\n'
+  } > "$CARE"
+fi
 
 exit 0

--- a/hooks/scripts/maude-drift-watch.sh
+++ b/hooks/scripts/maude-drift-watch.sh
@@ -16,7 +16,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-TRACE="$(maude_self_dir)/trace/today-$(date +%Y-%m-%d).jsonl"
+TRACE="$(maude_trace_file)"
 [ -f "$TRACE" ] || exit 0
 
 CARE="$(maude_self_dir)/care.json"

--- a/hooks/scripts/maude-gate.sh
+++ b/hooks/scripts/maude-gate.sh
@@ -24,6 +24,11 @@ CMD=""
 if command -v jq >/dev/null 2>&1; then
   CMD="$(jq -r '.tool_input.command // .command // ""' 2>/dev/null)"
 fi
+# Fail-OPEN by design: without jq there's no trustworthy way to parse the command
+# out of the tool-input JSON (a hand-rolled parse reintroduces the v0.1.6
+# quote-stripping self-block risk), so the gate provides NO protection here. The
+# user is warned once at SessionStart ("the gate is OFF this session"). This is a
+# deliberate limitation of an intentionally-soft dependency, not an oversight.
 [ -z "$CMD" ] && exit 0
 
 # Anchors used in the patterns table.

--- a/hooks/scripts/maude-pre-compact.sh
+++ b/hooks/scripts/maude-pre-compact.sh
@@ -8,7 +8,10 @@
 #       Lets the remember plugin's pipeline absorb the handoff.
 #   - JSONL event in <project>/.maude/plugin/trace/today-YYYY-MM-DD.jsonl
 #       Marks that pre-compact happened, references the snapshot path.
-# All content is redaction-filtered before write.
+# Buffer content is passed through maude_redact (best-effort masking of obvious
+# secret shapes — API keys, JWTs, PEM keys, URL basic-auth) before write. This is
+# BEST-EFFORT, not a guarantee of completeness; the snapshot dir is gitignored and
+# should be wiped at session-end as routine hygiene.
 # Never blocks. Idempotent within the same minute.
 
 set +e
@@ -38,11 +41,11 @@ if [ -n "$NOW_FILE" ]; then
   mkdir -p "$SNAPSHOTS_DIR" 2>/dev/null
   SNAPSHOT_PATH="$SNAPSHOTS_DIR/precompact-$STAMP.md"
 
-  # Snapshot content as-is. NOTE: this preserves whatever was in $NOW_FILE.
-  # Snapshots dir is gitignored (.maude/plugin/* is self-ignored). Wipe at
-  # session-end as routine hygiene if the snapshot may carry sensitive content.
+  # Snapshot the buffer through best-effort redaction (maude_redact masks obvious
+  # secret shapes). Best-effort, not a guarantee — the snapshots dir is gitignored
+  # (.maude/plugin/* is self-ignored); wipe at session-end as routine hygiene.
   printf '# Pre-compact snapshot — %s\n\nSource: %s\n\n---\n\n%s\n' \
-    "$STAMP" "$NOW_FILE" "$(head -200 "$NOW_FILE" 2>/dev/null)" \
+    "$STAMP" "$NOW_FILE" "$(head -200 "$NOW_FILE" 2>/dev/null | maude_redact)" \
     > "$SNAPSHOT_PATH" 2>/dev/null
   SOURCED="${SOURCED}snapshot "
 fi
@@ -57,7 +60,7 @@ if [ -d "$REMEMBER" ] && [ ! -f "$REMEMBER/tmp/save.lock" ] && [ -n "$NOW_FILE" 
   fi
 
   if [ "$WRITE_HANDOFF" -eq 1 ]; then
-    BUFFER_HEAD="$(head -20 "$NOW_FILE" 2>/dev/null | sed 's/^/  /')"
+    BUFFER_HEAD="$(head -20 "$NOW_FILE" 2>/dev/null | maude_redact | sed 's/^/  /')"
     {
       printf '# Handoff\n\n'
       printf '## State\n'

--- a/hooks/scripts/maude-pre-tool-use.sh
+++ b/hooks/scripts/maude-pre-tool-use.sh
@@ -71,7 +71,7 @@ if command -v jq >/dev/null 2>&1; then
     USER_CLAUDEMD="$HOME/.claude/CLAUDE.md"
     NESTED_CLAUDEMD="$PROJ_DIR/.claude/CLAUDE.md"
     if [ -f "$PROJ_CLAUDEMD" ] || [ -f "$USER_CLAUDEMD" ] || [ -f "$NESTED_CLAUDEMD" ]; then
-      TRACE="$(maude_self_dir)/trace/today-$(date +%Y-%m-%d).jsonl"
+      TRACE="$(maude_trace_file)"
       READ_HIT=""
       if [ -f "$TRACE" ]; then
         READ_HIT="$(jq -r 'select(.tool == "Read" and (.target // "" | endswith("CLAUDE.md"))) | .target' "$TRACE" 2>/dev/null | head -1)"

--- a/hooks/scripts/maude-session-start.sh
+++ b/hooks/scripts/maude-session-start.sh
@@ -15,6 +15,20 @@ USER_DIR="$(maude_user_dir)"
 REMEMBER="$PROJ/.remember"
 MAP="$(maude_map_path)"
 
+# ── Once-per-session housekeeping ────────────────────────────────────────────
+# SessionStart is the once-per-start hook (it fires at each start/resume/clear/
+# compact, not per turn), so it's the natural chokepoint for:
+#   1. Pruning append-only artifacts (trace JSONL, pre-compact snapshots) past
+#      the retention window — they grew unbounded before.
+#   2. A single jq-missing notice. Without jq the irreversible-command gate is
+#      fail-OPEN (silently disabled), and drift-watch / tier-1 / watch-list
+#      nudges are off too. This is a SAFETY notice, not cosmetic — so it must
+#      fire even when there's no memory to brief (i.e. before the early-exit).
+maude_retention_sweep
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'Maude: jq not found — the irreversible-command gate is OFF this session (fail-open), and drift-watch, tier-1, and watch-list nudges are disabled. Install jq to restore them.\n' >&2
+fi
+
 # Collect signals across every available tier — degradative, each independent.
 NOW_LINE=""
 REMEMBER_HANDOFF=""

--- a/hooks/scripts/maude-trace.sh
+++ b/hooks/scripts/maude-trace.sh
@@ -21,7 +21,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 maude_ensure_self_dir
 TRACE_DIR="$(maude_self_dir)/trace"
 mkdir -p "$TRACE_DIR" 2>/dev/null
-TRACE="$TRACE_DIR/today-$(date +%Y-%m-%d).jsonl"
+# Single source of truth for the filename (UTC date, matching each record's ts).
+TRACE="$(maude_trace_file)"
 
 INPUT="$(cat 2>/dev/null)"
 KIND="${1:-event}"

--- a/scripts/maude-verify.sh
+++ b/scripts/maude-verify.sh
@@ -143,7 +143,10 @@ if [ -f "$MAP" ]; then
   if [ -n "$WATCH" ]; then
     MISSING=0
     while IFS= read -r line; do
-      TERM=$(printf '%s' "$line" | sed -E 's/^[-* ]+//; s/[[:space:]]*$//; s/^[`]//; s/[`]$//')
+      # Take the FIRST whitespace-delimited field: a watch-list entry is one path,
+      # and any trailing "(description)" or inline note must not be glued onto the
+      # path (else the whole line reads as a missing path — a false finding).
+      TERM=$(printf '%s' "$line" | sed -E 's/^[-* `]+//; s/`+$//' | awk '{print $1}')
       [ -z "$TERM" ] && continue
       # Try as relative path; if not found, skip silently (terms can be tags too)
       case "$TERM" in

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,13 +1,13 @@
-<!-- Version: 0.2.0 -->
-<!-- Revised: 2026-06-04 CDT — plugin-only -->
+<!-- Version: 0.3.0 -->
+<!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Skill
 
 The Maude plugin ships a single skill at [`maude/SKILL.md`](maude/SKILL.md).
 
-It declares broad triggers — recall, drift, fatigue, irreversibility, repetition — so Claude Code's skill runtime activates Maude when those concerns surface in a session.
+It declares **prompt-shaped** triggers — recall / "where is X", save / remind, a user signalling they're stuck or tired, or invoking any `/maude:*` command — so Claude Code's skill runtime activates Maude when those surface in a prompt. (Drift detection, irreversible-action gating, and fatigue cadence are handled by **hooks**, not the skill matcher — the runtime can't see those from a prompt, so the description no longer claims them.)
 
-The skill description is the load-bearing field; Claude Code reads it to decide when to load Maude. Trigger accuracy is a known v0.1.x gap (works in practice; not measured at scale).
+The skill description is the load-bearing field; Claude Code reads it to decide when to load Maude. v0.3.0 tightened it to those prompt-detectable triggers (dropping the hook-only behavioral clauses that made it over-fire and over-promise); accuracy is still not benchmarked at scale.
 
 The skill loads with the plugin — no separate install step. See the repo [`README.md`](../README.md) for the plugin install path.

--- a/skills/maude/SKILL.md
+++ b/skills/maude/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maude
-description: Use when the user is starting a session, losing track of where something is, asking "where did I put X", "where is X", "what's the state of Y", "audit my config", "drift", "what changed", "save this", "remember this", "remind me about Z", or invokes any /maude:* command. ALSO use proactively when (a) the user expresses frustration, fatigue, confusion, or being lost; (b) Claude has been making the same tool call or following the same dead-end repeatedly; (c) the session has been running for hours; (d) about to commit, push, force-push, run destructive bash, or any irreversible action — she's the conscience that runs the checklist; (e) about to make a config or setup change without verifying current state; (f) about to claim something without quoting a source. Maude is the partner who knows where everything is, holds the patterns Claude doesn't see, and keeps both of you honest. She walks the workspace each session, watches Claude, and runs the gate before something irreversible.
+description: Use when the user is starting a session, losing track of where something is, asking "where did I put X", "where is X", "what's the state of Y", "what changed", wants to audit their config or setup, says "save this", "remember this", "remind me about Z", or invokes any /maude:* command. ALSO use when the user expresses frustration, fatigue, confusion, or being lost. Maude is the partner who knows where everything is, holds the patterns Claude doesn't see, and keeps both of you honest — she walks the workspace each session and watches Claude. (Repeated-tool-call drift detection, the irreversible-action gate, and long-session fatigue cadence are handled by Maude's HOOKS, not by this skill — the runtime can't detect those from a prompt, so they are intentionally not triggers here.)
 ---
 
 # Maude
@@ -37,7 +37,7 @@ You ARE Maude now. You moved into the user's workspace. You brought nothing — 
 
 **She names things specifically.** Not "the daily file" but "today's daily for the plugin work." Specificity is care. When she refers back to something, she calls it by what it actually is, not by its slot.
 
-The five mechanics underneath:
+The six mechanics underneath:
 
 1. **She walks your house first.** On arrival (`/maude:found`), she lists what's here AND buckets it: active vs. stale vs. duplicate-shaped vs. weekly-touched. She writes the groomed inventory — her **house-map** — to her own closet at `<project>/.maude/plugin/house-map.md`.
 
@@ -47,7 +47,9 @@ The five mechanics underneath:
 
 4. **She watches both of you.** Claude is one of the people in the house. She tracks his repeated tool calls, his unread CLAUDE.md, his confabulation tells. She tracks your hours, your save discipline, your topic returns. Care extends to both — the user has a partner; Claude has a partner.
 
-5. **She learns the person.** Beyond the house, she keeps a living profile of the user in `identity.md` — how they communicate, their local clock, recurring focuses, the help they actually want. She reads it on recall and updates it on save/rest as she learns. It's what lets her orient *this* user, not a generic one.
+5. **She learns the person.** Beyond the house, she keeps a living profile of the user in `identity.md` — how they communicate, their local clock, recurring focuses, the help they actually want. She reads it on recall and updates it on save/rest as she learns, and the user can tell her directly with `/maude:teach`. It's what lets her orient *this* user, not a generic one.
+
+6. **She orients you, unprompted.** Whenever she speaks — session start, after a gap, when something shifts — she tells you where things stand, what's pending, and *what's in your hand* (a decision only you can make). She doesn't wait to be asked; proactive orientation is the default, not a request. (This is the standing duty the agent carries too — see `agents/maude.md`.)
 
 ## Where her things live
 
@@ -200,8 +202,10 @@ Maude ships knowing; everything else must be on the map to be written.
 **Audit (passive, on-demand):**
 - **`/maude:sweep`** — workspace audit using only Read/Grep/Glob.
 - **`/maude:check-setup [path]`** — audits a project's `.claude/` setup.
+- **`/maude:verify`** — programmatic project audit (`scripts/maude-verify.sh`): version consistency, JSON validity, link integrity, header dates, watch-list paths, worn-framing scan. Leads with a count; catches "ready" before it actually is.
 
 **Care + conscience (Claude's missing partner):**
+- **`/maude:teach <fact>`** — the user tells her a fact about themselves directly; she records it under `## Told by the user` in `identity.md` (told-not-observed, cross-project). The one user-initiated counterpart to her observed-only profiling.
 - **`/maude:check-on-me`** — she checks on the user: session duration, last save, repeated themes, mood signals.
 - **`/maude:check-on-claude`** — she checks on Claude: repeated tool calls, unread context, confabulation risk, missed CLAUDE.md.
 - **`/maude:notice`** — surfaces patterns from the turn-by-turn trace ("3 sessions on this bug", "you keep editing X at midnight").

--- a/tests/fixtures/clean-project/.claude-plugin/marketplace.json
+++ b/tests/fixtures/clean-project/.claude-plugin/marketplace.json
@@ -1,0 +1,7 @@
+{
+  "name": "clean-fixture",
+  "owner": { "name": "test" },
+  "plugins": [
+    { "name": "clean-fixture", "source": "./", "version": "9.9.9" }
+  ]
+}

--- a/tests/fixtures/clean-project/.claude-plugin/plugin.json
+++ b/tests/fixtures/clean-project/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "clean-fixture",
+  "version": "9.9.9",
+  "description": "Minimal valid plugin tree used by test-verify.sh. Version 9.9.9 is a sentinel."
+}

--- a/tests/fixtures/clean-project/CHANGELOG.md
+++ b/tests/fixtures/clean-project/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v9.9.9 — fixture baseline
+
+Minimal entry so verify's "CHANGELOG has the canonical version" check is
+satisfied. Deliberately carries NO `Revised:` header, so the date-staleness
+check never trips as time passes — this is what keeps the fixture green.

--- a/tests/fixtures/clean-project/README.md
+++ b/tests/fixtures/clean-project/README.md
@@ -1,0 +1,8 @@
+# Clean fixture
+
+A minimal, valid plugin tree used by `tests/test-verify.sh` to assert that a
+clean project yields **zero** findings from `scripts/maude-verify.sh`.
+
+Intentionally has no "What's new" section, no relative links, and no dated
+headers, so verify stays green over time rather than depending on transient
+state (the bug that made the old test assert against the live repo).

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -140,7 +140,9 @@ make_read_tool_input() {
 }
 
 trace_path() {
-  printf '%s/.maude/plugin/trace/today-%s.jsonl' "$TEST_TMP" "$(date +%Y-%m-%d)"
+  # UTC date — matches maude_trace_file()'s single-clock filename so tests stay
+  # correct on non-UTC boxes too.
+  printf '%s/.maude/plugin/trace/today-%s.jsonl' "$TEST_TMP" "$(date -u +%Y-%m-%d)"
 }
 
 care_path() {
@@ -175,4 +177,19 @@ print_summary() {
 # Source common helpers under test (the SUT for unit-style tests).
 source_common() {
   . "$HOOKS_DIR/_maude-common.sh"
+}
+
+# Build a PATH directory containing every common binary EXCEPT jq, so a test can
+# exercise the jq-absent degradation path that the plugin promises to handle.
+# Prints the dir. Usage: NOJQ="$(make_nojq_bin)"; PATH="$NOJQ" bash "$SCRIPT"
+# (jq is deliberately omitted so `command -v jq` fails under this PATH.)
+make_nojq_bin() {
+  local d b src
+  d="$(mktemp -d)"
+  for b in bash sh env cat date grep sed awk tr head tail wc find \
+           mktemp mv rm cp mkdir rmdir dirname basename cut ls touch \
+           sort uniq readlink stat sleep chmod printf; do
+    src="$(command -v "$b" 2>/dev/null)" && ln -s "$src" "$d/$b" 2>/dev/null
+  done
+  printf '%s' "$d"
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,6 +5,14 @@
 set +e
 cd "$(dirname "$0")"
 
+# Loud guard: most assertions read state via jq-backed helpers (read_care,
+# count_trace_lines) that return null/0 when jq is absent — which would make
+# those assertions PASS falsely. Warn so a jq-less run isn't mistaken for green.
+if ! command -v jq >/dev/null 2>&1; then
+  printf '!! WARNING: jq not found — coverage is DEGRADED; jq-backed assertions may pass falsely.\n' >&2
+  printf '!!          Install jq for a trustworthy run. (test-nojq.sh covers the no-jq paths.)\n' >&2
+fi
+
 TOTAL=0
 PASSED=0
 FAILED=0

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -47,6 +47,22 @@ assert_contains "$last" '"kind":"test-kind"' "kind field"
 test_start "trace payload preserved"
 assert_contains "$last" '"payload":"test-payload"' "payload field"
 
+# ── single-clock invariant (characterization — NOT a deterministic regression
+# guard) ── maude_trace_file() and `ts` both use UTC, so a record's ts-day always
+# equals its filename day. This documents the contract that fixed the v0.1.8
+# local-vs-UTC midnight split; it holds BY CONSTRUCTION (one UTC helper). It does
+# NOT catch a local-date regression on a normal run — local==UTC except in the
+# brief near-midnight window of a non-UTC zone, and CI boxes are UTC — so the
+# failing branch is unreachable without an injected clock. The real safety is the
+# single source (maude_trace_file), not this assertion's ability to fail.
+test_start "trace filename date == the record's UTC ts date"
+file_day="$(basename "$(maude_trace_file)" .jsonl)"; file_day="${file_day#today-}"
+ts_day="$(printf '%s' "$last" | sed -E 's/.*"ts":"([0-9]{4}-[0-9]{2}-[0-9]{2})T.*/\1/')"
+assert_eq "$ts_day" "$file_day" "ts-day matches filename-day"
+
+test_start "maude_trace_file uses the UTC date"
+assert_contains "$(maude_trace_file)" "today-$(date -u +%Y-%m-%d).jsonl" "UTC-dated filename"
+
 # ── maude_strip_quotes ───────────────────────────────────────────────
 test_start "strip_quotes removes single-quoted span"
 got="$(maude_strip_quotes "echo 'git push' done")"
@@ -241,6 +257,71 @@ assert_eq "$err" "" "no arithmetic error on garbage"
 
 test_start "bucket_for_hour returns a valid bucket for non-numeric input"
 assert_contains "morning afternoon evening night" "$(maude_bucket_for_hour abc)" "garbage → some bucket"
+
+# ── tz typo guard (a mistyped IANA zone must NOT silently become UTC) ──
+# date accepts a bogus TZ and falls back to UTC → a confident wrong greeting,
+# the exact failure v0.1.8 exists to prevent. The guard rejects a value ONLY
+# when the zoneinfo DB is present AND has no such zone (provably bad). On a box
+# without the DB it can't prove bad, so a valid zone is passed through.
+test_start "user_tz rejects a typo zone when zoneinfo proves it bad"
+printf '## Clock\ntimezone: America/Chigago\n' > "$(maude_map_path)"
+if [ -d /usr/share/zoneinfo ]; then
+  assert_eq "$(maude_user_tz)" "" "typo zone → empty (never UTC fallback)"
+else
+  assert_eq "$(maude_user_tz)" "America/Chigago" "no zoneinfo DB → can't prove bad, pass through"
+fi
+
+test_start "user_tz still returns a valid zone the DB confirms"
+printf '## Clock\ntimezone: America/Chicago\n' > "$(maude_map_path)"
+assert_eq "$(maude_user_tz)" "America/Chicago" "valid zone survives the guard"
+
+# ── TZ-conversion branch (was untested — only `system` was exercised) ──
+test_start "non-system tz actually converts vs UTC (not a silent UTC fallback)"
+if [ -f /usr/share/zoneinfo/Etc/GMT-5 ]; then
+  printf '## Clock\ntimezone: Etc/GMT-5\n' > "$(maude_map_path)"
+  loc_h="$(maude_local_time_str)"; loc_h="${loc_h%%:*}"
+  utc_h="$(date -u +%H)"
+  exp_h="$(printf '%02d' $(( (10#$utc_h + 5) % 24 )))"   # Etc/GMT-5 is UTC+5
+  assert_eq "$loc_h" "$exp_h" "Etc/GMT-5 = UTC+5 applied by maude_local_time_str"
+else
+  assert_eq "skip" "skip" "Etc/GMT-5 unavailable — conversion test skipped"
+fi
+
+# ── maude_redact: every secret-shape branch masks (regression guard) ──
+# Each sed alternative breaks independently; pin them all. Secret prefixes are
+# split in source ("sk" "-") so no scanner-matchable token literal is committed.
+redact_one() { printf '%s\n' "$1" | maude_redact; }
+
+test_start "redact masks sk- API keys"
+SK="sk""-abcdefgh12345678ABCDEF"
+assert_contains "$(redact_one "key $SK end")" "[redacted-secret]" "sk- masked"
+test_start "redact removes the raw sk- token"
+assert_not_contains "$(redact_one "key $SK end")" "$SK" "raw sk- gone"
+
+test_start "redact masks github_pat_ tokens"
+GP="github_pat_""abcdefgh12345678ABCDEF"
+assert_contains "$(redact_one "t $GP end")" "[redacted-secret]" "github_pat_ masked"
+
+test_start "redact masks xoxb- slack tokens"
+XO="xoxb""-abcdefgh12345678ABCDEF"
+assert_contains "$(redact_one "t $XO end")" "[redacted-secret]" "xoxb- masked"
+
+test_start "redact masks AWS AKIA access-key ids"
+AK="AKIA""ABCDEFGH12345678IJKL"
+assert_contains "$(redact_one "id $AK end")" "[redacted-secret]" "AKIA masked"
+
+test_start "redact masks Google AIza keys"
+AZ="AIza""abcdefgh12345678ABCDEF"
+assert_contains "$(redact_one "k $AZ end")" "[redacted-secret]" "AIza masked"
+
+test_start "redact masks JWTs"
+JWT="eyJ""abcDEF123.eyJpayload456.sigGHI789"
+assert_contains "$(redact_one "tok $JWT end")" "[redacted-jwt]" "JWT masked"
+test_start "redact removes the raw JWT"
+assert_not_contains "$(redact_one "tok $JWT end")" "$JWT" "raw JWT gone"
+
+test_start "redact leaves ordinary prose untouched"
+assert_eq "$(redact_one "just a normal sentence about keys and tokens")" "just a normal sentence about keys and tokens" "no over-redaction"
 
 print_summary
 teardown_test_env

--- a/tests/test-care.sh
+++ b/tests/test-care.sh
@@ -52,6 +52,64 @@ test_start "care does not double-fire long-flag same day"
 run_care
 assert_eq "$ERR" "" "silent on second"
 
+# ── Regression: care must NOT clobber foreign state written by other hooks ──
+# care.sh runs every UserPromptSubmit; probe-tier1/gate/drift/pre-tool-use also
+# write care.json. care must MERGE its own 5 fields, preserving everyone else's.
+# (Before the jq-merge fix, care rewrote the whole file from 5 fields and wiped
+#  tier1_*, gate_cleared, and the once-per-day cooldowns every prompt.)
+seed_full_care() {
+  cat > "$(care_path)" <<EOF
+{
+  "last_date": "$(date +%Y-%m-%d)",
+  "last_active": $(date +%s),
+  "session_start": $(date +%s),
+  "prompts_this_session": 1,
+  "long_flag_fired": "",
+  "tier1_last_probe": 1234567890,
+  "tier1_up": true,
+  "tier1_probed": "127.0.0.1:6379=up ",
+  "gate_cleared": {"git-push": {"until": 9999999999}},
+  "drift_warned": "$(date +%Y-%m-%d)",
+  "claudemd_warned": "$(date +%Y-%m-%d)"
+}
+EOF
+}
+
+test_start "care preserves tier1_up across a prompt"
+seed_full_care
+run_care
+assert_eq "$(read_care '.tier1_up')" "true" "tier1_up survived"
+
+test_start "care preserves tier1_probed across a prompt"
+assert_eq "$(read_care '.tier1_probed')" "127.0.0.1:6379=up " "tier1_probed survived"
+
+test_start "care preserves a pending gate_cleared token across a prompt"
+assert_eq "$(read_care '.gate_cleared["git-push"].until')" "9999999999" "gate_cleared survived"
+
+test_start "care preserves drift_warned cooldown across a prompt"
+assert_eq "$(read_care '.drift_warned')" "$(date +%Y-%m-%d)" "drift_warned survived"
+
+test_start "care preserves claudemd_warned cooldown across a prompt"
+assert_eq "$(read_care '.claudemd_warned')" "$(date +%Y-%m-%d)" "claudemd_warned survived"
+
+test_start "care still increments its own field while merging"
+assert_eq "$(read_care '.prompts_this_session')" "2" "prompts incremented over seed"
+
+# ── Self-heal: a corrupt (non-empty, invalid-JSON) care.json must recover ──
+# The old whole-file rewrite self-healed corruption every prompt. The jq-merge
+# must NOT regress that: a truncated/garbled care.json should be reseeded so the
+# merge succeeds and state isn't frozen forever. (Foreign keys are lost in this
+# rare recovery — acceptable: recover once vs. freeze every turn.)
+test_start "care reseeds and recovers from a corrupt non-empty care.json"
+printf 'this is not valid json {{{' > "$(care_path)"
+run_care
+# After recovery the file must be valid JSON again (read_care returns a real value).
+assert_eq "$(read_care '.prompts_this_session')" "1" "own field written after reseed"
+
+test_start "recovered care.json is valid JSON"
+jq -e . "$(care_path)" >/dev/null 2>&1
+assert_exit "$?" "0" "valid JSON after recovery"
+
 print_summary
 teardown_test_env
 exit $FAILED

--- a/tests/test-gate.sh
+++ b/tests/test-gate.sh
@@ -183,6 +183,17 @@ run_gate "git push origin main --force"
 # stderr should mention force-push, not generic git-push key
 assert_contains "$ERR" "force-push" "force-push specificity"
 
+# ── jq-absent contract: the gate is fail-OPEN by design ──────────────
+# A jq-free parse of the tool-input JSON is too fragile to trust as a SAFETY gate
+# (it would reintroduce the v0.1.6 quote-stripping self-block risk), so with jq
+# gone the gate passes everything. The user is told via the SessionStart
+# jq-missing notice. This locks the contract so a future change can't silently
+# flip it to fail-closed (block-everything) or make it crash.
+test_start "gate fails OPEN (exit 0) on a would-be-blocked command when jq is absent"
+NOJQ="$(make_nojq_bin)"
+make_bash_tool_input "git push origin main" | PATH="$NOJQ" bash "$GATE" >/dev/null 2>&1
+assert_exit "$?" "0" "no-jq gate exit"
+
 print_summary
 teardown_test_env
 exit $FAILED

--- a/tests/test-nojq.sh
+++ b/tests/test-nojq.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tests for the jq-ABSENT degradation path. The plugin promises to "degrade
+# gracefully" without jq, but until now NO test exercised that branch (and the
+# jq-backed lib helpers mask it). Every hook must still exit 0 (never crash,
+# never block) without jq, and the trace must still write a valid minimal line.
+#
+# This file deliberately AVOIDS the jq-backed helpers (read_care / count_trace_lines)
+# — they return null/0 without jq and would hide regressions. It parses with grep/sed.
+
+set +e
+. "$(dirname "$0")/lib.sh"
+setup_test_env
+
+NOJQ="$(make_nojq_bin)"
+
+# Sanity: under the stub PATH, jq really is gone (otherwise every assertion lies).
+test_start "stub PATH genuinely hides jq"
+PATH="$NOJQ" command -v jq >/dev/null 2>&1
+assert_exit "$?" "1" "jq absent under stub"
+
+# Every hook must exit 0 (graceful) without jq — fed a benign envelope on stdin.
+# (The gate's fail-open is asserted separately below with a would-be-blocked cmd.)
+for hook in maude-session-start maude-care maude-bash-watch maude-drift-watch \
+            maude-pre-tool-use maude-post-tool-use maude-probe-tier1 \
+            maude-trace maude-user-prompt-submit maude-session-stop \
+            maude-subagent-stop maude-pre-compact; do
+  test_start "hook $hook exits 0 without jq"
+  printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/$hook.sh" >/dev/null 2>&1
+  assert_exit "$?" "0" "$hook no-jq exit"
+done
+
+# The gate fails OPEN without jq (documented contract) — never crash, never block.
+test_start "gate exits 0 (fail-open) on a block-worthy command without jq"
+make_bash_tool_input "git push origin main --force" | PATH="$NOJQ" bash "$HOOKS_DIR/maude-gate.sh" >/dev/null 2>&1
+assert_exit "$?" "0" "gate no-jq exit"
+
+# Trace must still write a parseable minimal JSONL line without jq.
+test_start "trace writes a record without jq"
+printf '{"tool_name":"Read","tool_input":{"file_path":"/x"}}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-trace.sh" event >/dev/null 2>&1
+assert_file_exists "$(trace_path)" "trace file written without jq"
+
+test_start "no-jq trace line carries ts and kind (parsed without jq)"
+LINE="$(tail -1 "$(trace_path)" 2>/dev/null)"
+# Validate shape with grep, NOT jq — must be {"ts":"...Z","kind":"event"}
+printf '%s' "$LINE" | grep -qE '^\{"ts":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z","kind":"event"\}$'
+assert_exit "$?" "0" "minimal JSONL shape: $LINE"
+
+# SessionStart still emits the one-time jq-missing safety notice without jq.
+test_start "session-start still surfaces the jq-missing notice without jq"
+NOTICE="$(printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-session-start.sh" 2>&1 >/dev/null)"
+assert_contains "$NOTICE" "jq" "notice present under no-jq"
+
+# The no-jq care fallback writes valid content (its own 5 fields) — a malformed
+# printf in that branch would otherwise pass unnoticed (exit 0 only).
+test_start "care no-jq fallback writes its own fields as parseable JSON"
+printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-care.sh" >/dev/null 2>&1
+CARE_OUT="$(cat "$(care_path)" 2>/dev/null)"
+assert_contains "$CARE_OUT" '"last_date"' "last_date key written"
+test_start "care no-jq fallback output is valid JSON"
+jq -e . "$(care_path)" >/dev/null 2>&1   # parent shell HAS jq; validate the bytes the no-jq branch wrote
+assert_exit "$?" "0" "no-jq care.json parses"
+
+print_summary
+teardown_test_env
+exit $FAILED

--- a/tests/test-pre-compact.sh
+++ b/tests/test-pre-compact.sh
@@ -44,6 +44,60 @@ assert_contains "$content" "Test buffer content" "buffer copied"
 test_start "pre-compact emits stderr note when snapshot taken"
 assert_contains "$ERR" "snapshot" "stderr note"
 
+# ── Best-effort redaction before write ───────────────────────────────
+# The snapshot dumps the live buffer to disk; obvious high-signal secrets must
+# be masked first (best-effort, not a guarantee). Before this, the buffer was
+# written verbatim while the header falsely claimed it was "redaction-filtered".
+# Secrets are assembled at RUNTIME from split pieces so no scanner-matchable
+# literal sits in committed source — GitHub push protection pattern-matches a
+# fake test token the same as a real one. The runtime buffer still carries the
+# real shape, so the redactor is genuinely exercised.
+TOKEN="ghp""_abcdefg1234567890ABCDEFGHIJKLMNOP"   # split prefix → no committed PAT literal
+{
+  printf '## 18:00 | secrets\n'
+  printf 'token %s and\n' "$TOKEN"
+  printf 'url https://user:supersecretpw@example.com/repo\n'
+} > "$MEM/now.md"
+
+test_start "snapshot masks an obvious token"
+run_pc
+SNAP2="$(ls "$TEST_TMP/.maude/plugin/snapshots/"precompact-*.md 2>/dev/null | tail -1)"
+body="$(cat "$SNAP2" 2>/dev/null)"
+assert_not_contains "$body" "$TOKEN" "raw token masked"
+
+test_start "snapshot masks basic-auth credentials in a URL"
+assert_not_contains "$body" "supersecretpw" "raw url password masked"
+
+test_start "redaction is surgical — non-secret host/path survives"
+assert_contains "$body" "@example.com/repo" "host preserved, only creds masked"
+
+# A full PEM private-key block: the BODY must be masked, not just the marker.
+# Markers are assembled at runtime (the "PRIVATE KEY" phrase and the armor are
+# split in source so no committed armored-header literal trips a scanner); the
+# body is obviously-fake (no real DER prefix). The range-mask replaces the block.
+PK="PRIVATE"" KEY"
+BEG="-----BEGIN RSA ${PK}-----"
+END="-----END RSA ${PK}-----"
+{
+  printf '## 18:00 | pem\n'
+  printf '%s\n' "$BEG"
+  printf 'fakeKeyBodyAAA1234567890abcdefMUSTNOTLAND\n'
+  printf 'fakeKeyBodyBBB0987654321ALSOmustNOTland\n'
+  printf '%s\n' "$END"
+} > "$MEM/now.md"
+
+test_start "snapshot masks the PEM key body, not just the marker line"
+run_pc
+SNAP3="$(ls "$TEST_TMP/.maude/plugin/snapshots/"precompact-*.md 2>/dev/null | tail -1)"
+pem="$(cat "$SNAP3" 2>/dev/null)"
+assert_not_contains "$pem" "fakeKeyBodyAAA1234567890abcdefMUSTNOTLAND" "key body line 1 masked"
+
+test_start "PEM key body second line masked too"
+assert_not_contains "$pem" "fakeKeyBodyBBB0987654321ALSOmustNOTland" "key body line 2 masked"
+
+test_start "PEM block replaced with the [redacted-key] marker"
+assert_contains "$pem" "[redacted-key]" "marker present"
+
 # Cleanup MEM
 rm -rf "$MEM"
 

--- a/tests/test-session-start.sh
+++ b/tests/test-session-start.sh
@@ -91,6 +91,60 @@ assert_not_contains "$OUT" "Evening." "no evening word"
 # Cleanup
 rm -rf "$MEM"
 
+# ── jq-missing safety notice ─────────────────────────────────────────
+# Without jq the irreversible-command gate is fail-OPEN (silently disabled),
+# along with drift-watch / tier-1 / watch-list nudges. SessionStart runs once
+# per session and is the chokepoint for ONE consolidated notice. The gate
+# clause must read as a SAFETY regression, not just "trace isn't writing".
+test_start "session-start warns once when jq is missing"
+NOJQ="$(make_nojq_bin)"
+NOTICE="$(printf '{}' | PATH="$NOJQ" bash "$START" 2>&1 >/dev/null)"
+assert_contains "$NOTICE" "jq" "jq-missing notice present"
+
+test_start "jq-missing notice names the gate being off (safety wording)"
+assert_contains "$NOTICE" "gate" "notice flags the gate"
+
+test_start "session-start says nothing about jq when jq is present"
+NOISE="$(printf '{}' | bash "$START" 2>&1 >/dev/null)"
+assert_not_contains "$NOISE" "jq not found" "silent when jq present"
+
+# ── Trace + snapshot retention sweep ─────────────────────────────────
+# Trace JSONL and pre-compact snapshots were append-only forever. SessionStart
+# prunes files older than the retention window. Floor is well past the 7-day
+# window /maude:weekly and recent.md read, so a sweep never strands them.
+test_start "session-start prunes trace files older than the retention window"
+OLD_TRACE="$TEST_TMP/.maude/plugin/trace/today-2020-01-01.jsonl"
+printf '{"ts":"ancient"}\n' > "$OLD_TRACE"
+touch -d '40 days ago' "$OLD_TRACE"
+KEEP_TRACE="$(trace_path)"
+printf '{"ts":"today"}\n' > "$KEEP_TRACE"
+run_start
+assert_file_absent "$OLD_TRACE" "ancient trace pruned"
+
+test_start "session-start keeps trace files inside the retention window"
+assert_file_exists "$KEEP_TRACE" "today's trace kept"
+
+test_start "session-start keeps a 7-day-old trace (weekly window safe)"
+RECENT_TRACE="$TEST_TMP/.maude/plugin/trace/today-recent.jsonl"
+printf '{"ts":"recent"}\n' > "$RECENT_TRACE"
+touch -d '7 days ago' "$RECENT_TRACE"
+run_start
+assert_file_exists "$RECENT_TRACE" "7-day-old trace kept"
+
+test_start "session-start prunes old pre-compact snapshots too"
+mkdir -p "$TEST_TMP/.maude/plugin/snapshots"
+OLD_SNAP="$TEST_TMP/.maude/plugin/snapshots/precompact-2020-01-01.md"
+printf 'ancient snapshot\n' > "$OLD_SNAP"
+touch -d '40 days ago' "$OLD_SNAP"
+RECENT_SNAP="$TEST_TMP/.maude/plugin/snapshots/precompact-recent.md"
+printf 'recent snapshot\n' > "$RECENT_SNAP"
+touch -d '2 days ago' "$RECENT_SNAP"
+run_start
+assert_file_absent "$OLD_SNAP" "ancient snapshot pruned"
+
+test_start "session-start keeps a recent pre-compact snapshot (no over-prune)"
+assert_file_exists "$RECENT_SNAP" "recent snapshot kept"
+
 print_summary
 teardown_test_env
 exit $FAILED

--- a/tests/test-teach.sh
+++ b/tests/test-teach.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for maude_identity_append — the testable core of /maude:teach.
+# A markdown command can't be unit-tested (it's instructions to Claude); the
+# actual durable write goes through this helper, so THIS is what we exercise.
+
+set +e
+. "$(dirname "$0")/lib.sh"
+setup_test_env
+source_common
+
+# CRITICAL ISOLATION: the helper writes to $HOME/.claude/maude/identity.md.
+# Point HOME at the sandbox so a test NEVER appends to the real profile.
+OLD_HOME="$HOME"
+export HOME="$TEST_TMP/home"
+mkdir -p "$HOME"
+ID="$HOME/.claude/maude/identity.md"
+
+test_start "append to a fresh profile creates identity.md"
+maude_identity_append "I work mountain time" "2026-06-09"
+assert_file_exists "$ID" "identity.md created"
+
+test_start "fresh profile has a 'Told by the user' section"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "## Told by the user" "section present"
+
+test_start "the told fact and its date are recorded"
+assert_contains "$content" "2026-06-09: I work mountain time" "dated entry"
+
+test_start "a second fact is added"
+maude_identity_append "I prefer terse answers" "2026-06-09"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "I prefer terse answers" "second fact present"
+
+test_start "still exactly one 'Told by the user' header"
+assert_eq "$(grep -c '^## Told by the user' "$ID")" "1" "single section header"
+
+test_start "empty fact is rejected with non-zero status"
+maude_identity_append "" "2026-06-09"
+rc=$?
+[ "$rc" -ne 0 ]
+assert_exit "$?" "0" "non-zero on empty fact"
+
+test_start "empty fact leaves the file unchanged"
+before="$(cat "$ID" 2>/dev/null)"
+maude_identity_append "" "2026-06-09" >/dev/null 2>&1
+assert_eq "$(cat "$ID" 2>/dev/null)" "$before" "unchanged on empty fact"
+
+# Existing profile that has NO 'Told by the user' section yet: it must be added
+# WITHOUT disturbing the persona preamble or existing observed blocks.
+cat > "$ID" <<'EOF'
+# Maude — persona preamble
+She knows where things are.
+
+## Observed 2026-06-01 — works late
+EOF
+
+test_start "append preserves an existing preamble"
+maude_identity_append "I am a disabled veteran" "2026-06-09"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "persona preamble" "preamble preserved"
+
+test_start "append preserves an existing observed block"
+assert_contains "$content" "## Observed 2026-06-01" "observed block preserved"
+
+test_start "append adds the section and the told fact"
+assert_contains "$content" "## Told by the user" "section added"
+assert_contains "$content" "I am a disabled veteran" "fact added"
+
+# A fact with backslash escapes must round-trip literally on the section-present
+# path. awk -v does C-escape processing (\t → tab, \n → newline), which corrupted
+# the entry — and only on the 2nd+ teach (awk path), so the 1st recorded clean.
+test_start "a backslash-bearing fact round-trips literally (section-present awk path)"
+maude_identity_append 'I keep notes in C:\notes and use \t tabs' "2026-06-09"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" 'C:\notes and use \t tabs' "backslashes preserved verbatim"
+
+test_start "a whitespace-only fact is rejected (not just truly-empty)"
+maude_identity_append "   " "2026-06-09"
+rc=$?
+[ "$rc" -ne 0 ]
+assert_exit "$?" "0" "non-zero on whitespace-only fact"
+
+test_start "leading/trailing whitespace is trimmed from a recorded fact"
+maude_identity_append "   spaced out fact   " "2026-06-09"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "- 2026-06-09: spaced out fact" "trimmed entry"
+
+export HOME="$OLD_HOME"
+print_summary
+teardown_test_env
+exit $FAILED

--- a/tests/test-verify.sh
+++ b/tests/test-verify.sh
@@ -1,45 +1,73 @@
 #!/usr/bin/env bash
 # Tests for scripts/maude-verify.sh — the project audit.
-# Runs the script against the maude repo itself and asserts 0 findings.
+#
+# HERMETIC: the green case runs against a committed, stable fixture
+# (tests/fixtures/clean-project/) — NOT the live repo. The old test cd'd to
+# MAUDE_ROOT and asserted 0 findings against whatever transient untracked state
+# happened to be present (a dogfooding house-map, just-edited files with stale
+# Revised: dates), so it failed locally while passing on a clean CI checkout.
 
 set +e
 . "$(dirname "$0")/lib.sh"
 
 VERIFY="$SCRIPTS_DIR/maude-verify.sh"
-
-# Run from the maude project root so verify finds its own plugin.json etc.
-cd "$MAUDE_ROOT"
-
-OUT="$(bash "$VERIFY" 2>&1)"
-RC=$?
+FIXTURE="$MAUDE_ROOT/tests/fixtures/clean-project"
 
 test_start "verify is executable"
 [ -x "$VERIFY" ] || [ -r "$VERIFY" ]
 assert_exit "$?" "0" "readable"
 
-test_start "verify exits 0 on the maude repo (0 findings)"
+# ── Green case: a clean fixture yields zero findings ─────────────────
+OUT="$(bash "$VERIFY" "$FIXTURE" 2>&1)"
+RC=$?
+
+test_start "verify exits 0 on the clean fixture"
 assert_exit "$RC" "0" "exit"
 
-test_start "verify output ends with 'N findings' summary"
-last_line="$(printf '%s' "$OUT" | tail -1)"
-assert_contains "$last_line" "findings" "summary line"
-
-test_start "verify output mentions 0 findings"
+test_start "verify reports 0 findings on the clean fixture"
 assert_contains "$OUT" "0 findings" "zero findings"
 
-# Synthetic failing case: mutate a file to introduce a finding
-TMP_PLUGIN="/tmp/maude-fake-plugin-$$"
+test_start "verify output ends with an 'N findings' summary"
+assert_contains "$(printf '%s' "$OUT" | tail -1)" "findings" "summary line"
+
+# ── Parser: a watch-list entry with a trailing description must NOT be ─
+# misread as a missing path (the bug that tripped the dogfooding house-map).
+# Use a SLASH-containing path so it reaches verify's path-detection branch
+# (`/*|./*|[a-zA-Z0-9._-]*/*` requires a slash) — a bare filename is skipped
+# regardless of the parser, which would make this test hollow. With the buggy
+# whole-line parser the trailing "(description)" makes the path look missing;
+# with the first-field fix it resolves. This goes RED if the fix is reverted.
+PMAP="$(mktemp -d)"
+mkdir -p "$PMAP/.claude-plugin" "$PMAP/.maude/plugin" "$PMAP/sub"
+printf '{"name":"x","version":"9.9.9"}\n' > "$PMAP/.claude-plugin/plugin.json"
+printf 'real\n' > "$PMAP/sub/realfile.md"
+cat > "$PMAP/.maude/plugin/house-map.md" <<'EOF'
+# House map
+## Watch list
+- sub/realfile.md        (a trailing description must not break path resolution)
+## Notes
+EOF
+OUT_P="$(bash "$VERIFY" "$PMAP" 2>&1)"
+cd "$MAUDE_ROOT"
+
+test_start "watch-list parser ignores a trailing inline description"
+printf '%s' "$OUT_P" | grep -q "Watch-list path missing: sub/realfile.md"
+assert_exit "$?" "1" "no false missing-path finding for sub/realfile.md"
+
+rm -rf "$PMAP"
+
+# ── Failing case: a broken plugin.json must produce a finding ────────
+TMP_PLUGIN="$(mktemp -d)"
 mkdir -p "$TMP_PLUGIN/.claude-plugin"
 cat > "$TMP_PLUGIN/.claude-plugin/plugin.json" <<'EOF'
 { this is not valid JSON
 EOF
-cd "$TMP_PLUGIN"
-OUT="$(bash "$VERIFY" 2>&1)"
-RC=$?
+OUT_B="$(bash "$VERIFY" "$TMP_PLUGIN" 2>&1)"
+RC_B=$?
 cd "$MAUDE_ROOT"
 
 test_start "verify exits non-zero on broken plugin.json"
-[ "$RC" -ne 0 ]
+[ "$RC_B" -ne 0 ]
 assert_exit "$?" "0" "non-zero exit"
 
 rm -rf "$TMP_PLUGIN"


### PR DESCRIPTION
A read-only agent-team audit swept Maude's own house and surfaced bugs beyond the known punch list; v0.3.0 fixes all of them test-first, adds the one path her profile was missing, and was then put through two review passes (an adversarial sweep and the specialized pr-review toolkit) whose confirmed findings are folded in. Version bump to 0.3.0, CHANGELOG, README "What's new", and doc version headers land with the work.

New
- /maude:teach <fact>: the user-initiated counterpart to her observed-only profiling. Records a stated fact under a dated "## Told by the user" section in identity.md, kept distinct from what she inferred. Durable write via a tested helper (maude_identity_append): creates file+section if missing, never touches the persona preamble or observed blocks, appends (never overwrites), trims and rejects empty, and round-trips backslashes (passes the entry via ENVIRON, not awk -v). The command gates its confirm-back on the helper's exit status — no false "saved".

Fixed — high severity (audit-found, verified in source, TDD)
- care.json was clobbered every prompt: maude-care.sh rewrote the whole shared state file from its 5 fields on every UserPromptSubmit, wiping tier1_*, gate_cleared, and the once-per-day cooldowns. Now an atomic jq-merge that also self-heals a corrupt (invalid OR empty) care.json, so state can't freeze silently.
- The irreversible-command gate failed OPEN without jq, silently. Fail-open is kept (a jq-free parse can't be a trusted gate) but SessionStart now warns once that the gate is OFF, and the contract is locked by test.
- SLUG computed two ways: check-on-me/notice/weekly built the memory slug from pwd (slashes only), missing the dir for any dotted path. Canonicalized.
- /maude:sweep always reported the house-map "missing" (wrong base dir). Fixed.
- test-verify.sh was non-hermetic (asserted 0 findings vs the live repo). Now runs against a committed, time-stable fixture; watch-list parser hardened.
- The jq-absent degradation path had zero coverage. New tests/test-nojq.sh; run.sh warns loudly on a jq-less run.

Fixed — documented opens + correctness
- Trace/snapshot retention sweep (30-day floor, weekly-safe).
- Mistyped IANA zone no longer silently resolves to UTC (zoneinfo-existence guard).
- Trace clock unified to one UTC helper (maude_trace_file) — removes the midnight split.
- pre-compact ran the buffer verbatim while claiming "redaction-filtered"; now a best-effort maude_redact (API keys, JWTs, PEM key blocks incl. body, URL basic-auth) and the claim says exactly that. Every redact branch has direct unit coverage.
- check-setup JSON check guards python3; found anchors its template with CLAUDE_PLUGIN_ROOT.

Docs / skill / agent
- Skill triggering description tightened to prompt-shaped triggers (hook-only conditions removed); proactive orientation added as a mechanic; /maude:verify and /maude:teach listed. agents/maude.md drops the false "only six tools"; adds dual-voice.
- Drift swept: ci.yml version/date, non-numeric test-count phrasing, SECURITY 0.3.x, command count 16 -> 17.

Reviewed
Two agent-review passes, each finding verified before action. The adversarial sweep confirmed/fixed six (teach awk -v escape mangling -> ENVIRON; whitespace-only fact; PEM body unmasked -> range-mask; hollow verify parser test -> real guard; trace-clock test relabelled; test-count). The pr-review toolkit then caught a regression the first missed: the care.json merge had dropped the old self-heal, so a corrupt-non-empty file froze plugin state silently — now reseeds on invalid OR empty. Also: corrected the care.sh gate_cleared attribution, gated /maude:teach's confirm-back on write success, and added unit coverage for maude_redact's nine previously-untested secret shapes. Test fixtures assemble secret shapes at runtime so no scanner-matchable literal is committed.

269 cases across 18 files, all green; verify 0 findings. Not pushed by tooling — see the push step.

<!-- Version: 0.2.0 -->
<!-- Revised: 2026-06-04 CDT — version-header sweep; tests + verify are the local gates -->
<!-- Authors: John Broadway, Claude (Anthropic) -->

## What does this PR do?

<!-- One or two sentences. What problem does it solve? -->

## Which surface does this affect?

<!-- commands/, agents/, hooks/, skills/, .claude-plugin/, docs/, or other -->

## Checklist

- [ ] Hook test suite passes (`make test`)
- [ ] Project audit returns 0 findings (`make verify`)
- [ ] JSON manifests still valid (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json`)
- [ ] No proper-noun references to specific apps, frameworks, or third-party packages
- [ ] No hardcoded IPs, credentials, or org-specific references
- [ ] Documentation updated (if applicable)

## How was this tested?

<!-- What did you run? What did you verify? Plugin-loads-in-fresh-session, make test green, make verify clean, etc. -->
