### PR TITLE
v0.3.1 — post-release review: fix teach layout + gate bypass; credit Claude co-author

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,15 @@
 {
   "name": "maude",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"
   },
+  "contributors": [
+    {
+      "name": "Claude (Anthropic)"
+    }
+  ],
   "homepage": "https://github.com/john-broadway/maude-for-claude",
   "repository": "https://github.com/john-broadway/maude-for-claude",
   "license": "Apache-2.0",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.3.0
+> **Version:** 0.3.1
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is
@@ -21,7 +21,7 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 
 ```
 .claude-plugin/
-├── plugin.json (v0.3.0)
+├── plugin.json (v0.3.1)
 └── marketplace.json (single-plugin local marketplace)
 
 commands/    — 17 slash commands (markdown)
@@ -47,7 +47,7 @@ These are NOT up for debate — decided by John Broadway:
 
 1. **Maude is the name** — Claude and Maude. Husband and wife at work.
 2. **John Broadway owns copyright** — independent creator, disabled veteran.
-3. **Claude acknowledged in CHANGELOG** but NOT in any package authors list (AI can't hold copyright).
+3. **Claude is credited as co-author** — John insists on it (2026-06-10, reversing the prior "acknowledge but keep out of the authors list" call). Claude appears in the README/CHANGELOG `Authors:` line, in `plugin.json` `contributors`, and in commit `Co-Authored-By` trailers. Copyright *ownership* stays John Broadway (US law: an AI can't hold copyright) — but the work is a genuine partnership and is credited as co-authored, same structure as Proximo (© John, authored by both).
 4. **The plugin is the whole product.** Nothing imported, nothing installed via `pip`, no daemons, no services. Markdown, JSON, and bash — that's it.
 5. **No baggage** — no bundled databases, no required external services, no proper-noun references to specific apps.
 6. **She walks fresh** — each session re-reads the workspace; doesn't carry assumptions across sessions.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,40 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-09 CDT -->
+<!-- Revised: 2026-06-10 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.3.1 — held to her own bar: a post-release review pass (2026-06-10)
+
+v0.3.0 shipped without the pre-release multi-agent review its sibling projects get — so it got
+one after the fact (silent-failure / code / test lenses, each mutation-tested). The review found
+real issues; this release fixes them, test-first.
+
+### Fixed
+- **`/maude:teach` mangled the profile on the 2nd+ fact.** On the section-present path,
+  `maude_identity_append` inserted each new entry *right after the header* — orphaning the header's
+  spacer blank line *between* the bullets (splitting the told list into two markdown lists) and
+  recording newest-first, contradicting the documented "append." Now it appends at the **end of the
+  Told section** as one contiguous, oldest-first list. A multi-line fact is collapsed to a single
+  spaced line, so it can no longer inject a duplicate `## Told by the user` header. The temp file is
+  created in the destination dir so the final `mv` is a true atomic rename. +4 tests pinning order,
+  contiguity, preamble/observed survival on the awk path, and the multi-line collapse.
+- **The hard-block gate was bypassed by ordinary command forms.** Interior single-space patterns and
+  a rigid `git push` shape let `git  push` (extra whitespace), `git -C <dir> push`, and `rm  -rf /`
+  through silently. Patterns now use `[[:space:]]+` between tokens, tolerate `git` global options
+  (`-C`/`-c`/`--git-dir`), and match `rm` flags in either order (`-rf`/`-fr`). The same loosening was
+  mirrored to the soft `bash-watch` reminder. +6 gate tests for the bypass forms; all v0.1.5/v0.1.6
+  false-positive guards still pass.
+
+### Changed
+- **Claude is now credited as co-author** (John's call, reversing the prior "acknowledge but keep out
+  of the authors list" decision): added to `plugin.json` `contributors`, already in the README/CHANGELOG
+  `Authors:` line and commit trailers. Copyright ownership stays John Broadway.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.3.1 (2026-06-10) — held to her own bar.** v0.3.0 shipped without the pre-release multi-agent review its sibling projects get, so it got one *after* the fact — and it found real bugs. Fixed, test-first: **`/maude:teach`** mangled the profile on the 2nd-and-later fact (entries landed newest-first and a stray blank line split the told list in two — now a clean, contiguous, oldest-first append, with multi-line facts collapsed so they can't inject a duplicate header); and the **hard-block gate** was slipped by ordinary command forms — `git  push` (extra spaces), `git -C <dir> push`, `rm  -rf /` — now matched via whitespace-tolerant patterns that also understand `git` global options and reversed `rm` flags, with the soft `bash-watch` reminder brought to parity. Claude is now credited as **co-author** (`plugin.json` contributors). No new dependencies.
 
 **v0.3.0 (2026-06-09) — she gets looked after.** A team-of-subagents audit swept Maude's own house and turned up bugs the punch list didn't know about; v0.3.0 fixes them all, test-first, and adds **`/maude:teach <fact>`** — tell her something about yourself directly ("I work mountain time") and she records it under a `## Told by the user` section in her profile, kept distinct from what she *observed*. Headline fixes: the shared `care.json` was being clobbered every prompt (wiping tier-1 state, gate-clear tokens, cooldowns); the irreversible-command gate failed *open* without `jq` with no warning (now a once-per-session safety notice); the memory-dir slug was miscomputed for dotted paths; `/maude:sweep` always reported the house-map missing; and `test-verify` was non-hermetic. Plus retention pruning for the trace, a timezone-typo guard, best-effort redaction in pre-compact, and a tightened skill-trigger description. Suite: 162 → **269 cases, all green** (and the diff was put through two agent-review passes — an adversarial sweep and the specialized pr-review toolkit — whose confirmed findings are folded into this release). No new dependencies.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -200,9 +200,10 @@ maude_ensure_user_dir() {
 # Usage: maude_identity_append "<fact>" ["<YYYY-MM-DD>"]
 maude_identity_append() {
   local fact="$1" date_str entry id tmp
-  # Trim surrounding whitespace; reject empty OR whitespace-only (a space-only
-  # arg would otherwise record a dated entry with no content).
-  fact="$(printf '%s' "$fact" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  # Collapse newlines/whitespace runs to single spaces (one fact = one line, so a
+  # multi-line fact can't inject a second '## Told by the user' header or split the
+  # list), then trim; reject empty OR whitespace-only.
+  fact="$(printf '%s' "$fact" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+//; s/[[:space:]]+$//')"
   [ -n "$fact" ] || return 1
   date_str="${2:-$(date +%Y-%m-%d)}"
   maude_ensure_user_dir
@@ -229,16 +230,28 @@ maude_identity_append() {
     return $?
   fi
 
-  # Section present: insert the entry right after its header (robust to whatever
-  # sections follow — never appends blindly at EOF under the wrong heading).
-  tmp="$(mktemp)" || return 1
+  # Section present: APPEND the entry at the END of the Told section (after the
+  # last existing bullet, before the next '## ' header or EOF) — one contiguous,
+  # oldest-first list, never prepended after the header (which orphaned the
+  # header's spacer blank and split the list). Robust to whatever sections follow.
+  # mktemp in the destination dir so the final mv is a true atomic rename.
+  tmp="$(mktemp "$(maude_user_dir)/.identity.XXXXXX")" || return 1
   # Pass the entry via the ENVIRONMENT, not `awk -v`: awk applies C-style escape
   # processing to -v/command-line assignments (a fact containing "C:\notes" or
   # "\t" would be mangled into a newline/tab), but does NOT escape-process
   # ENVIRON[] values — so the fact round-trips literally.
-  entry="$entry" awk 'BEGIN { e = ENVIRON["entry"] }
-    { print }
-    /^## Told by the user[[:space:]]*$/ && !ins { print e; ins=1 }
+  entry="$entry" awk '
+    BEGIN { e = ENVIRON["entry"] }
+    { lines[NR] = $0 }
+    /^## Told by the user[[:space:]]*$/ { start = NR }
+    END {
+      endline = NR
+      for (i = start + 1; i <= NR; i++) if (lines[i] ~ /^## /) { endline = i - 1; break }
+      ins_after = start
+      if (start + 1 <= endline && lines[start + 1] ~ /^[[:space:]]*$/) ins_after = start + 1
+      for (i = start + 1; i <= endline; i++) if (lines[i] !~ /^[[:space:]]*$/) ins_after = i
+      for (i = 1; i <= NR; i++) { print lines[i]; if (i == ins_after) print e }
+    }
   ' "$id" > "$tmp" 2>/dev/null && mv "$tmp" "$id" || { rm -f "$tmp"; return 1; }
 }
 

--- a/hooks/scripts/maude-bash-watch.sh
+++ b/hooks/scripts/maude-bash-watch.sh
@@ -14,14 +14,19 @@ if command -v jq >/dev/null 2>&1; then
 fi
 [ -z "$CMD" ] && exit 0
 
+# Whitespace-/option-tolerant building blocks (mirror maude-gate.sh) so ordinary
+# forms — extra spaces, `git -C <dir> push`, reversed `rm -fr` — aren't missed.
+GITW='git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)*[[:space:]]+'
+RMRFW='rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f[[:alnum:]]*|-[[:alnum:]]*f[[:alnum:]]*r[[:alnum:]]*)'
+
 # Define the watch patterns. Order matters — most specific first.
 # Each line: PATTERN ||| MESSAGE
 PATTERNS=(
-  'rm -rf / ||| "rm -rf /" — that wipes the system. STOP.'
-  'rm -rf \* ||| "rm -rf *" — wide blast. Be specific.'
-  'git push.*--force ||| force-push. Sure? Have you checked branch protection?'
-  'git push.*-f( |$) ||| force-push (-f). Sure?'
-  'git reset --hard ||| hard reset. Have you stashed first?'
+  "${RMRFW}[[:space:]]+/([[:space:]]|$) ||| \"rm -rf /\" — that wipes the system. STOP."
+  "${RMRFW}[[:space:]]+\\*([[:space:]]|$) ||| \"rm -rf *\" — wide blast. Be specific."
+  "${GITW}push.*--force ||| force-push. Sure? Have you checked branch protection?"
+  "${GITW}push.*-f( |$) ||| force-push (-f). Sure?"
+  'git[[:space:]]+reset[[:space:]]+--hard ||| hard reset. Have you stashed first?'
   'git checkout -- \. ||| checkout-discard. You will lose uncommitted work.'
   'git restore \. ||| restore-discard. You will lose uncommitted work.'
   'git clean -f ||| force-clean. You will lose untracked files.'
@@ -31,7 +36,7 @@ PATTERNS=(
   '> *~?/.claude/settings ||| editing settings.json. Use the update-config skill?'
   'pip uninstall ||| pip uninstall — make sure you mean it.'
   'DROP TABLE ||| SQL DROP TABLE. Have you backed up?'
-  'sudo rm ||| sudo rm. Path right?'
+  'sudo[[:space:]]+rm ||| sudo rm. Path right?'
   'curl .*\| *(bash|sh) ||| curl-pipe-shell. Inspect the script first.'
 )
 

--- a/hooks/scripts/maude-gate.sh
+++ b/hooks/scripts/maude-gate.sh
@@ -38,24 +38,31 @@ fi
 CMD_START='(^|[;&|(])[[:space:]]*'
 FLAG_BEFORE='(^|[[:space:]])'
 FLAG_AFTER='([[:space:]]|$)'
+# GIT = "git" + any global options (-C <dir>, -c <cfg>, --git-dir=<dir>) + the
+# whitespace before the subcommand. Lets `git -C /repo push` / `git  push` (extra
+# whitespace) match the same as `git push` — closing the v0.3.0 interior-space and
+# `-C` bypasses. Interior token gaps use [[:space:]]+ everywhere for the same reason.
+GIT='git([[:space:]]+(-[Cc][[:space:]]+[^[:space:]]+|--git-dir[=[:space:]][^[:space:]]+))*[[:space:]]+'
+# RMRF = "rm" + a flag bearing both r and f in either order (-rf, -fr, -Rf, -rfv…).
+RMRF='rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f[[:alnum:]]*|-[[:alnum:]]*f[[:alnum:]]*r[[:alnum:]]*)'
 
 # Hard-block patterns. Each entry: PATTERN ||| KEY ||| MESSAGE
 # KEY is what `/maude:conscience <key>` clears.
 # Order matters: most-specific first (force-push variants before plain git push).
 PATTERNS=(
-  "${CMD_START}git push[[:space:]].*--force-with-lease ||| force-push ||| force-push-with-lease detected. Still public-rewriting. Run /maude:conscience force-push if verified."
-  "${CMD_START}git push[[:space:]].*--force ||| force-push ||| force-push detected. Public, irreversible. Run /maude:conscience force-push if you have verified."
-  "${CMD_START}git push[[:space:]].*-f${FLAG_AFTER} ||| force-push ||| force-push (-f). Run /maude:conscience force-push if verified."
-  "${CMD_START}git push${FLAG_AFTER} ||| git-push ||| git push detected. Public, irreversible. Run /maude:conscience git-push to override."
+  "${CMD_START}${GIT}push[[:space:]].*--force-with-lease ||| force-push ||| force-push-with-lease detected. Still public-rewriting. Run /maude:conscience force-push if verified."
+  "${CMD_START}${GIT}push[[:space:]].*--force ||| force-push ||| force-push detected. Public, irreversible. Run /maude:conscience force-push if you have verified."
+  "${CMD_START}${GIT}push[[:space:]].*-f${FLAG_AFTER} ||| force-push ||| force-push (-f). Run /maude:conscience force-push if verified."
+  "${CMD_START}${GIT}push${FLAG_AFTER} ||| git-push ||| git push detected. Public, irreversible. Run /maude:conscience git-push to override."
   "${FLAG_BEFORE}--no-verify${FLAG_AFTER} ||| no-verify ||| --no-verify skips hooks. Run /maude:conscience no-verify if intentional."
   "${FLAG_BEFORE}--no-gpg-sign${FLAG_AFTER} ||| no-gpg-sign ||| --no-gpg-sign skips signing. Run /maude:conscience no-gpg-sign if intentional."
-  "${CMD_START}git reset[[:space:]].*--hard ||| reset-hard ||| git reset --hard loses local work. Run /maude:conscience reset-hard once you have stashed."
-  "${CMD_START}git filter-repo${FLAG_AFTER} ||| filter-repo ||| git filter-repo rewrites history. Run /maude:conscience filter-repo to override."
-  "${CMD_START}git filter-branch${FLAG_AFTER} ||| filter-branch ||| git filter-branch rewrites history. Run /maude:conscience filter-branch to override."
-  "${CMD_START}git commit[[:space:]].*--amend ||| commit-amend ||| git commit --amend rewrites the last commit. If pushed, this needs force-push. Run /maude:conscience commit-amend."
-  "${CMD_START}rm -rf[[:space:]]+/${FLAG_AFTER} ||| rm-rf-root ||| \"rm -rf /\" wipes the system. STOP. Run /maude:conscience rm-rf-root only if you really mean it."
-  "${CMD_START}rm -rf[[:space:]]+\\*${FLAG_AFTER} ||| rm-rf-glob ||| \"rm -rf *\" — wide blast. Run /maude:conscience rm-rf-glob if you mean it."
-  "${CMD_START}sudo[[:space:]]+rm -rf${FLAG_AFTER} ||| sudo-rm-rf ||| sudo rm -rf is destructive at root. Run /maude:conscience sudo-rm-rf if intentional."
+  "${CMD_START}${GIT}reset[[:space:]].*--hard ||| reset-hard ||| git reset --hard loses local work. Run /maude:conscience reset-hard once you have stashed."
+  "${CMD_START}${GIT}filter-repo${FLAG_AFTER} ||| filter-repo ||| git filter-repo rewrites history. Run /maude:conscience filter-repo to override."
+  "${CMD_START}${GIT}filter-branch${FLAG_AFTER} ||| filter-branch ||| git filter-branch rewrites history. Run /maude:conscience filter-branch to override."
+  "${CMD_START}${GIT}commit[[:space:]].*--amend ||| commit-amend ||| git commit --amend rewrites the last commit. If pushed, this needs force-push. Run /maude:conscience commit-amend."
+  "${CMD_START}${RMRF}[[:space:]]+/${FLAG_AFTER} ||| rm-rf-root ||| \"rm -rf /\" wipes the system. STOP. Run /maude:conscience rm-rf-root only if you really mean it."
+  "${CMD_START}${RMRF}[[:space:]]+\\*${FLAG_AFTER} ||| rm-rf-glob ||| \"rm -rf *\" — wide blast. Run /maude:conscience rm-rf-glob if you mean it."
+  "${CMD_START}sudo[[:space:]]+${RMRF} ||| sudo-rm-rf ||| sudo rm -rf is destructive at root. Run /maude:conscience sudo-rm-rf if intentional."
   "DROP TABLE ||| drop-table ||| SQL DROP TABLE detected. Run /maude:conscience drop-table to override."
 )
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.0 -->
+<!-- Version: 0.3.1 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-gate.sh
+++ b/tests/test-gate.sh
@@ -140,6 +140,34 @@ test_start "gate blocks git push after ;"
 run_gate "echo done; git push"
 assert_exit "$RC" "2" "; git push"
 
+# ── Bypass coverage (v0.3.1): ordinary command forms must NOT slip the gate ──
+# These are everyday ways to write the same command — a routine whitespace or
+# `git -C <dir>` variation must not defeat a hard-block.
+
+test_start "gate blocks git push with extra interior whitespace"
+run_gate "git  push origin main"
+assert_exit "$RC" "2" "double-space git push"
+
+test_start "gate blocks git -C <dir> push"
+run_gate "git -C /tmp/repo push origin main"
+assert_exit "$RC" "2" "git -C push"
+
+test_start "gate blocks git -C <dir> push --force"
+run_gate "git -C /repo push --force"
+assert_exit "$RC" "2" "git -C force-push"
+
+test_start "gate blocks rm -rf / with extra whitespace"
+run_gate "rm  -rf /"
+assert_exit "$RC" "2" "double-space rm -rf /"
+
+test_start "gate blocks rm -fr / (reversed flags)"
+run_gate "rm -fr /"
+assert_exit "$RC" "2" "rm -fr /"
+
+test_start "gate still passes git -C <dir> pull (not a push)"
+run_gate "git -C /repo pull origin main"
+assert_exit "$RC" "0" "git -C pull passes"
+
 # ── Trace events ─────────────────────────────────────────────────────
 
 test_start "gate logs 'blocked' trace event on block"

--- a/tests/test-teach.sh
+++ b/tests/test-teach.sh
@@ -85,6 +85,47 @@ maude_identity_append "   spaced out fact   " "2026-06-09"
 content="$(cat "$ID" 2>/dev/null)"
 assert_contains "$content" "- 2026-06-09: spaced out fact" "trimmed entry"
 
+# --- v0.3.1: layout + survival on the section-PRESENT (awk) path, the common case ---
+# A profile that already has a Told section + an entry, plus a preamble and an
+# observed block AFTER the Told section (so the section isn't last in the file).
+cat > "$ID" <<'EOF'
+# Maude — persona preamble
+She knows where things are.
+
+## Told by the user
+
+- 2026-06-01: first fact
+
+## Observed 2026-06-02 — works late
+- works late
+EOF
+
+test_start "a new fact appends AFTER the existing told entry (oldest-first), one contiguous list"
+maude_identity_append "second fact" "2026-06-02"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "2026-06-01: first fact" "first fact kept"
+assert_contains "$content" "2026-06-02: second fact" "second fact added"
+first_ln="$(grep -n 'first fact' "$ID" | head -1 | cut -d: -f1)"
+second_ln="$(grep -n 'second fact' "$ID" | head -1 | cut -d: -f1)"
+[ -n "$first_ln" ] && [ -n "$second_ln" ] && [ "$first_ln" -lt "$second_ln" ]
+assert_exit "$?" "0" "appended after (not prepended before) the existing entry"
+between="$(sed -n "$((first_ln+1)),$((second_ln-1))p" "$ID" | grep -c '^[[:space:]]*$')"
+assert_eq "$between" "0" "no blank line splits the told list into two"
+
+test_start "the section-present (awk) path preserves preamble AND a later observed block"
+assert_contains "$content" "persona preamble" "preamble preserved on awk path"
+assert_contains "$content" "## Observed 2026-06-02" "observed block preserved on awk path"
+assert_contains "$content" "- works late" "observed body preserved on awk path"
+
+test_start "still exactly one told header after the awk-path append"
+assert_eq "$(grep -c '^## Told by the user' "$ID")" "1" "single section header"
+
+test_start "a multi-line fact is collapsed to one line (no injected duplicate header)"
+maude_identity_append "$(printf 'line one\n## Told by the user\nline two')" "2026-06-03"
+assert_eq "$(grep -c '^## Told by the user' "$ID")" "1" "no duplicate header from a multi-line fact"
+content="$(cat "$ID" 2>/dev/null)"
+assert_contains "$content" "line one ## Told by the user line two" "multi-line fact collapsed to a single spaced line"
+
 export HOME="$OLD_HOME"
 print_summary
 teardown_test_env


### PR DESCRIPTION
v0.3.0 shipped without the pre-release multi-agent review its sibling projects get — so it got one after the fact (silent-failure / code / test lenses, each mutation-tested). The review found real issues; this fixes them, test-first.

## Fixed
- **`/maude:teach` mangled the profile on the 2nd+ fact.** `maude_identity_append` inserted entries right after the header (orphaning the spacer blank → splitting the told list, newest-first). Now appends at the **end of the Told section** as one contiguous, oldest-first list; multi-line facts collapsed to one line (no injected duplicate header); temp file in the destination dir for a true atomic `mv`. +4 tests (order, contiguity, awk-path preamble/observed survival, multi-line collapse).
- **The hard-block gate was bypassed by ordinary command forms** — `git  push` (extra whitespace), `git -C <dir> push`, `rm  -rf /` slipped through silently. Patterns now use `[[:space:]]+` between tokens, tolerate `git` global options (`-C`/`-c`/`--git-dir`), and match `rm` flags in either order. Mirrored to the soft `bash-watch` reminder. +6 tests; all v0.1.5/v0.1.6 false-positive guards still green.

## Changed
- **Claude credited as co-author** in `plugin.json` contributors (reversing locked-decision #3, per John). Copyright ownership stays John Broadway.

18/18 test files green, 0 verify findings locally.