### PR TITLE
v0.3.2 — close the v0.3.1 review's remaining opens

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.3.1
+> **Version:** 0.3.2
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is
@@ -21,7 +21,7 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 
 ```
 .claude-plugin/
-├── plugin.json (v0.3.1)
+├── plugin.json (v0.3.2)
 └── marketplace.json (single-plugin local marketplace)
 
 commands/    — 17 slash commands (markdown)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,39 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-10 CDT -->
+<!-- Revised: 2026-06-11 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.3.2 — closing the review's last opens (2026-06-11)
+
+The v0.3.1 review surfaced one MEDIUM and three coverage gaps beyond the two bugs it fixed.
+This release closes them, test-first.
+
+### Fixed
+- **Without `jq`, `care.sh` clobbered foreign state every prompt.** The no-jq fallback rewrote
+  `care.json` from care's own 5 fields, silently wiping the keys other hooks keep there
+  (`tier1_*`, `gate_cleared`, `drift_warned`, `claudemd_warned`) on every `UserPromptSubmit`. Since
+  care can neither read nor merge its fields without a JSON parser anyway (its read path is jq-gated,
+  so the long-session nudge can't fire), the no-jq branch is now a **no-op** — care is inert without
+  `jq` (the SessionStart notice already says the hooks are degraded) but no longer destroys shared
+  state. +3 no-clobber tests.
+
+### Tests (closing review-flagged coverage gaps)
+- **`drift_warned` was seeded with the wrong shape.** `test-care.sh` seeded a flat string, but
+  `drift-watch` writes a nested object (`.grep` + `.read_targets[path]`) — the merge test passed
+  against a value the code never writes. Reseeded with the real shape; asserts a nested path survives.
+- **Slug-drift guard.** The memory-dir slug is inlined into ~13 command files rather than calling
+  `maude_slug` — the root cause of the v0.3.0 "computed two ways" bug. A new guard fails if any
+  command's inline transform drifts from the canonical one in `_maude-common.sh`.
+- **No-jq notice ordering, pinned on a pristine project.** The existing no-jq notice test ran after
+  earlier cases had seeded memory, so it couldn't catch a regression that moved the safety notice
+  below the brief's early-exit. A new case runs against a pristine project (nothing to brief) and
+  asserts the notice still fires.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.3.2 (2026-06-11) — closing the review's last opens.** The v0.3.1 review flagged a MEDIUM and three coverage gaps it didn't fix; this closes them, test-first. Headline: without `jq`, `care.sh` was rewriting the shared `care.json` from its own fields every prompt — silently wiping the state other hooks keep there (tier-1, gate-clear tokens, cooldowns). Since care can't read or merge without a JSON parser anyway, the no-jq path is now a **no-op** — inert without `jq`, but no longer destructive. Plus three test-only hardenings: the `drift_warned` merge test now seeds the *real* nested shape (it was asserting a value the code never writes), a guard fails if any command's inlined memory-slug drifts from the canonical one (the root cause of the v0.3.0 "computed two ways" bug), and the no-jq safety notice is now pinned on a pristine project so a reorder below the early-exit can't slip through. No new dependencies.
 
 **v0.3.1 (2026-06-10) — held to her own bar.** v0.3.0 shipped without the pre-release multi-agent review its sibling projects get, so it got one *after* the fact — and it found real bugs. Fixed, test-first: **`/maude:teach`** mangled the profile on the 2nd-and-later fact (entries landed newest-first and a stray blank line split the told list in two — now a clean, contiguous, oldest-first append, with multi-line facts collapsed so they can't inject a duplicate header); and the **hard-block gate** was slipped by ordinary command forms — `git  push` (extra spaces), `git -C <dir> push`, `rm  -rf /` — now matched via whitespace-tolerant patterns that also understand `git` global options and reversed `rm` flags, with the soft `bash-watch` reminder brought to parity. Claude is now credited as **co-author** (`plugin.json` contributors). No new dependencies.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/maude-care.sh
+++ b/hooks/scripts/maude-care.sh
@@ -65,17 +65,13 @@ if command -v jq >/dev/null 2>&1; then
      '. + {last_date: $ld, last_active: ($la|tonumber), session_start: ($ss|tonumber), prompts_this_session: ($p|tonumber), long_flag_fired: $lf}' \
      "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE" || rm -f "$TMP"
 else
-  # No jq — fall back to a minimal rewrite (foreign keys can't be preserved without
-  # a JSON parser; the SessionStart jq-missing notice warns the user this is degraded).
-  {
-    printf '{\n'
-    printf '  "last_date": "%s",\n' "$TODAY"
-    printf '  "last_active": %s,\n' "$NOW"
-    printf '  "session_start": %s,\n' "$SESSION_START"
-    printf '  "prompts_this_session": %d,\n' "$PROMPTS"
-    printf '  "long_flag_fired": "%s"\n' "$LONG_FLAG_FIRED"
-    printf '}\n'
-  } > "$CARE"
+  # No jq — leave care.json UNTOUCHED. Without a JSON parser, care can neither read
+  # its own fields (the read block above is jq-gated, so the long-session nudge can
+  # never fire) nor merge — and a scratch rewrite would CLOBBER every foreign key
+  # that other hooks keep here (tier1_*, gate_cleared, drift_warned, claudemd_warned)
+  # on every prompt. care is simply inert without jq (the SessionStart notice already
+  # tells the user the hooks are degraded); it must not destroy shared state to be so.
+  :
 fi
 
 exit 0

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.1 -->
+<!-- Version: 0.3.2 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -323,6 +323,33 @@ assert_not_contains "$(redact_one "tok $JWT end")" "$JWT" "raw JWT gone"
 test_start "redact leaves ordinary prose untouched"
 assert_eq "$(redact_one "just a normal sentence about keys and tokens")" "just a normal sentence about keys and tokens" "no over-redaction"
 
+# ── Slug consistency: the memory-dir slug is INLINED into ~13 command .md files
+# rather than calling maude_slug(). The root cause of the v0.3.0 "computed two ways"
+# bug (dotted paths reading nothing) is that duplication — the fix synced the copies
+# but left them as copies. This guard fails if any command's inline transform drifts
+# from the canonical one in _maude-common.sh, so a future edit can't desync silently.
+test_start "the canonical slug transform is found in _maude-common.sh"
+CANON="$(sed -n "s/.*| sed '\([^']*\)'.*/\1/p" "$HOOKS_DIR/_maude-common.sh" | grep 'a-zA-Z0-9' | head -1)"
+[ -n "$CANON" ]
+assert_exit "$?" "0" "canonical transform present"
+
+bad=""
+for f in "$MAUDE_ROOT"/commands/*.md; do
+  while IFS= read -r line; do
+    case "$line" in
+      *SLUG=*sed*)
+        expr="$(printf '%s' "$line" | sed -n "s/.*sed '\([^']*\)'.*/\1/p")"
+        if [ -n "$expr" ] && [ "$expr" != "$CANON" ]; then
+          bad="$bad $(basename "$f")[$expr]"
+        fi
+        ;;
+    esac
+  done < "$f"
+done
+test_start "no command inlines a non-canonical slug transform"
+[ -z "$bad" ]
+assert_exit "$?" "0" "all command slugs canonical${bad:+ — DRIFT:$bad}"
+
 print_summary
 teardown_test_env
 exit $FAILED

--- a/tests/test-care.sh
+++ b/tests/test-care.sh
@@ -69,7 +69,7 @@ seed_full_care() {
   "tier1_up": true,
   "tier1_probed": "127.0.0.1:6379=up ",
   "gate_cleared": {"git-push": {"until": 9999999999}},
-  "drift_warned": "$(date +%Y-%m-%d)",
+  "drift_warned": {"grep": "$(date +%Y-%m-%d)", "read_targets": {"/x/CLAUDE.md": "$(date +%Y-%m-%d)"}},
   "claudemd_warned": "$(date +%Y-%m-%d)"
 }
 EOF
@@ -86,8 +86,11 @@ assert_eq "$(read_care '.tier1_probed')" "127.0.0.1:6379=up " "tier1_probed surv
 test_start "care preserves a pending gate_cleared token across a prompt"
 assert_eq "$(read_care '.gate_cleared["git-push"].until')" "9999999999" "gate_cleared survived"
 
-test_start "care preserves drift_warned cooldown across a prompt"
-assert_eq "$(read_care '.drift_warned')" "$(date +%Y-%m-%d)" "drift_warned survived"
+test_start "care preserves the NESTED drift_warned cooldown across a prompt"
+# drift-watch writes drift_warned as an OBJECT (.grep + .read_targets[path]), not a
+# flat string — seed + assert the real shape so this guards what the code writes.
+assert_eq "$(read_care '.drift_warned.grep')" "$(date +%Y-%m-%d)" "drift_warned.grep survived"
+assert_eq "$(read_care '.drift_warned.read_targets["/x/CLAUDE.md"]')" "$(date +%Y-%m-%d)" "drift_warned.read_targets survived"
 
 test_start "care preserves claudemd_warned cooldown across a prompt"
 assert_eq "$(read_care '.claudemd_warned')" "$(date +%Y-%m-%d)" "claudemd_warned survived"
@@ -109,6 +112,23 @@ assert_eq "$(read_care '.prompts_this_session')" "1" "own field written after re
 test_start "recovered care.json is valid JSON"
 jq -e . "$(care_path)" >/dev/null 2>&1
 assert_exit "$?" "0" "valid JSON after recovery"
+
+# ── No-jq: care must LEAVE care.json untouched (not clobber foreign keys) ──
+# Without jq, care can't read/merge its own fields anyway; a scratch rewrite would
+# wipe tier1_*, gate_cleared, drift_warned, claudemd_warned every prompt. v0.3.2:
+# the no-jq branch is now a no-op, so the shared file survives intact.
+test_start "care does NOT clobber foreign keys when jq is absent"
+seed_full_care
+NOJQ="$(make_nojq_bin)"
+before="$(cat "$(care_path)")"
+printf '{"prompt":"hi"}' | PATH="$NOJQ" bash "$CARE" >/dev/null 2>&1
+after="$(cat "$(care_path)")"
+assert_eq "$after" "$before" "care.json untouched without jq"
+
+test_start "the foreign keys are still present after a no-jq care run"
+assert_eq "$(read_care '.tier1_up')" "true" "tier1_up intact after no-jq run"
+assert_eq "$(read_care '.gate_cleared["git-push"].until')" "9999999999" "gate_cleared intact after no-jq run"
+assert_eq "$(read_care '.drift_warned.grep')" "$(date +%Y-%m-%d)" "nested drift_warned intact after no-jq run"
 
 print_summary
 teardown_test_env

--- a/tests/test-nojq.sh
+++ b/tests/test-nojq.sh
@@ -50,15 +50,24 @@ test_start "session-start still surfaces the jq-missing notice without jq"
 NOTICE="$(printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-session-start.sh" 2>&1 >/dev/null)"
 assert_contains "$NOTICE" "jq" "notice present under no-jq"
 
-# The no-jq care fallback writes valid content (its own 5 fields) — a malformed
-# printf in that branch would otherwise pass unnoticed (exit 0 only).
-test_start "care no-jq fallback writes its own fields as parseable JSON"
+# v0.3.2: without jq, care is a NO-OP — it must not touch care.json. care can't
+# read/merge its own fields without a JSON parser anyway, and a scratch rewrite
+# would clobber the foreign keys other hooks keep in the shared file every prompt.
+test_start "care no-jq run exits 0"
 printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-care.sh" >/dev/null 2>&1
-CARE_OUT="$(cat "$(care_path)" 2>/dev/null)"
-assert_contains "$CARE_OUT" '"last_date"' "last_date key written"
-test_start "care no-jq fallback output is valid JSON"
-jq -e . "$(care_path)" >/dev/null 2>&1   # parent shell HAS jq; validate the bytes the no-jq branch wrote
-assert_exit "$?" "0" "no-jq care.json parses"
+assert_exit "$?" "0" "care exits 0 without jq"
+
+test_start "care without jq does NOT create care.json from scratch"
+rm -f "$(care_path)"   # clean slate (an earlier hook in this file may have created it)
+printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-care.sh" >/dev/null 2>&1
+[ ! -f "$(care_path)" ]
+assert_exit "$?" "0" "no care.json created under no-jq"
+
+test_start "care without jq leaves an existing care.json (with foreign keys) untouched"
+printf '{"tier1_up":true,"gate_cleared":{"git-push":{"until":9999999999}}}\n' > "$(care_path)"
+before="$(cat "$(care_path)")"
+printf '{}' | PATH="$NOJQ" bash "$HOOKS_DIR/maude-care.sh" >/dev/null 2>&1
+assert_eq "$(cat "$(care_path)")" "$before" "care.json byte-identical after no-jq run"
 
 print_summary
 teardown_test_env

--- a/tests/test-session-start.sh
+++ b/tests/test-session-start.sh
@@ -104,6 +104,16 @@ assert_contains "$NOTICE" "jq" "jq-missing notice present"
 test_start "jq-missing notice names the gate being off (safety wording)"
 assert_contains "$NOTICE" "gate" "notice flags the gate"
 
+# Pins the ORDERING the script comment calls load-bearing: the safety notice must
+# fire BEFORE the early-exit, so it still shows on a PRISTINE project with no memory
+# or house-map to brief. (The test above runs after earlier cases seeded memory, so
+# it can't catch a regression that moved the notice below the brief's early-exit.)
+test_start "jq-missing notice fires even on a pristine project (nothing to brief)"
+PRISTINE="$(mktemp -d)"
+NOTICE_BARE="$(printf '{}' | CLAUDE_PROJECT_DIR="$PRISTINE" HOME="$PRISTINE/home" PATH="$NOJQ" bash "$START" 2>&1 >/dev/null)"
+assert_contains "$NOTICE_BARE" "gate" "notice fires with no memory/house-map present"
+rm -rf "$PRISTINE"
+
 test_start "session-start says nothing about jq when jq is present"
 NOISE="$(printf '{}' | bash "$START" 2>&1 >/dev/null)"
 assert_not_contains "$NOISE" "jq not found" "silent when jq present"


### PR DESCRIPTION
The v0.3.1 review surfaced one MEDIUM and three coverage gaps beyond the two bugs it fixed. This closes them, test-first.

## Fixed
- **Without `jq`, `care.sh` clobbered foreign state every prompt.** The no-jq fallback rewrote `care.json` from care's own 5 fields, silently wiping the keys other hooks keep there (`tier1_*`, `gate_cleared`, `drift_warned`, `claudemd_warned`). care can't read/merge its fields without a JSON parser anyway, so the no-jq branch is now a **no-op** — inert without `jq`, no longer destructive. +3 no-clobber tests.

## Tests (review-flagged gaps)
- `drift_warned` seed corrected from a flat string to the real nested object shape (`.grep` + `.read_targets[path]`) — the merge test was asserting a value the code never writes.
- New **slug-drift guard**: fails if any command's inlined memory-slug transform diverges from the canonical one in `_maude-common.sh` (root cause of the v0.3.0 "computed two ways" bug).
- New **pristine-project no-jq notice** test, pinning that the safety notice fires before the brief's early-exit.

18/18 test files green, 0 verify findings. Haiku redteam of the no-op change: no findings.