### PR TITLE
Maude v0.4.1 — doc-sync pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.4.0
+> **Version:** 0.4.1
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is
@@ -21,7 +21,7 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 
 ```
 .claude-plugin/
-├── plugin.json (v0.4.0)
+├── plugin.json (v0.4.1)
 └── marketplace.json (single-plugin local marketplace)
 
 commands/    — 17 slash commands (markdown)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.0 -->
+<!-- Version: 0.4.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-11 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,33 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.4.1 — doc-sync pass (2026-06-11)
+
+The v0.4.0 release bumped the canonical version but missed **seven** `<!-- Version: -->`
+headers — including the README's own — and the `docs/launch/` drafts still spoke as of
+v0.1.5, nine CHANGELOG releases back. The user felt the drift between the docs before any
+tool measured it. This release fixes every instance and, more importantly, gives the verifier
+the check that was missing.
+
+### Added
+- **`maude-verify`: version-header sync check.** Every markdown `<!-- Version: -->` header
+  must match the canonical `plugin.json` version; each stale file is its own finding
+  (`STALE HEADER: <file> says Version: X (expected Y)`). The release convention was always
+  bump-all-headers — now it's enforced, not remembered. +3 tests.
+
+### Fixed
+- **Seven stale version headers** bumped to current: `README.md`, `SECURITY.md`,
+  `CODE_OF_CONDUCT.md`, `skills/README.md`, both issue templates, and the PR template.
+- **`docs/launch/` refreshed from the v0.1.5 era to the current surface.** The social-copy
+  thread and Show-HN draft now describe what she actually is today (teach, verify,
+  dual-voice, local-time greeting, the letter to her next self); the posting checklist no
+  longer instructs pushing a v0.1.5 tag; the demo storyboard is de-versioned so it can't
+  rot the same way again.
+
+No new dependencies.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-09 CDT -->
+<!-- Revised: 2026-06-11 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 <div align="center">
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.4.1 (2026-06-11) — doc-sync pass.** v0.4.0 missed seven `<!-- Version: -->` headers (including this README's own) and the `docs/launch/` drafts still spoke as of v0.1.5 — nine CHANGELOG releases back. All fixed — and `maude-verify` now has a **version-header sync check**, so a stale header is a counted finding instead of something a human has to feel. The release convention was always bump-all-headers; now it's enforced, not remembered.
 
 **v0.4.0 (2026-06-11) — a letter waiting when she arrives.** Maude walks fresh each session by design — but fresh never meant *no inheritance*. Until now her cross-project home held a profile of the user (`identity.md`) and a profile of Claude (`patterns.md`) — and nothing of herself. New: **`letter-from-maude.md`**, her letter to her next self. `/maude:rest` rewrites it (what kind of partner she was, what she caught, what she missed, what to do differently — tone and judgment, ≤20 lines; a quiet session leaves the prior letter in place rather than overwrite it with filler). `/maude:wake` and `/maude:brief` read it on arrival, and the SessionStart brief surfaces its first line automatically — so the inheritance fires even when nobody asks. One markdown file; no new dependencies; the facts still live in the digests — the letter carries what they can't.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -12,5 +12,5 @@ Internal-facing prep material for the public showing. Not user docs; not part of
 ## House rules
 
 - **Personal-space rule** still applies. Don't link to anything that points back into the development workspace. The public repo is the front door.
-- **3-team push rule** still applies. None of these artifacts should be published until John explicitly says go.
+- **Independent-review rule** still applies. None of these artifacts should be published until John explicitly says go.
 - **Don't claim what isn't tested.** Fresh-machine install on someone else's box is unverified at scale; don't promise it as a feature in launch copy.

--- a/docs/launch/demo-storyboard.md
+++ b/docs/launch/demo-storyboard.md
@@ -39,7 +39,7 @@ sudo docker restart maude-demo-postgres
 sleep 3
 ```
 
-At this point: the container is running on a fresh empty postgres init at the old path; the original 6-second-old data is at `staged-recipe/data/postgres/`; the workspace has a root-owned ghost-shaped directory at the old path. Exactly the failure mode v0.1.1 was built for.
+At this point: the container is running on a fresh empty postgres init at the old path; the original 6-second-old data is at `staged-recipe/data/postgres/`; the workspace has a root-owned ghost-shaped directory at the old path. Exactly the failure mode the running-services walk was built for.
 
 ## Recording
 
@@ -69,7 +69,7 @@ ls recipe/
 1. *"This is the failure mode where a directory rename leaves a running stack pointed at a path that no longer exists."*
 2. *"Plain `ls` shows you a tree; it doesn't tell you that a process is bind-mounted to an old version of it."*
 3. *"Maude's arrival walk does. She lists running containers, reconciles their bind mounts against the filesystem, and tells you which are intact, which are orphaned, and which are empty stubs the daemon auto-created."*
-4. *"That's the v0.1.1 upgrade — running-services awareness in the arrival walk."*
+4. *"That's the running-services awareness in the arrival walk."*
 
 ## Cleanup after recording
 
@@ -84,4 +84,4 @@ sudo rm -rf /tmp/maude-demo
 - Best clip is the `[GHOST]` line scrolling past — that's the moment.
 - The `ls recipe/` reveal is the proof-of-blindspot — keep it tight.
 - Don't speed up the walk's output; let it scroll at native speed. Reading her output IS the demo.
-- Subtitle worth showing: `v0.1.1 — running-services walk, 2026-05-04`
+- Subtitle worth showing: `maude — the running-services walk`

--- a/docs/launch/social-copy.md
+++ b/docs/launch/social-copy.md
@@ -30,9 +30,11 @@ A short thread on what that means. 🧵
 - `/maude:check-on-me` — care side, pattern-of-life
 - `/maude:conscience` — pre-irreversible-action gate
 
-**4/** v0.1.4 wired her whisper layer. Drift detection: she notes when Claude reads the same file repeatedly or hammers Grep. Pre-irreversible gate: hard-blocks `git push` and other destructive commands until cleared via `/maude:conscience`. CLAUDE.md unread check: she reminds you before an edit if Claude hasn't read the rules. Both Claude and you hear her.
+**4/** Her whisper layer runs on hooks. Drift detection: she notes when Claude reads the same file repeatedly or hammers Grep. Pre-irreversible gate: hard-blocks `git push` and other destructive commands until cleared via `/maude:conscience`. CLAUDE.md unread check: she reminds you before an edit if Claude hasn't read the rules. Both Claude and you hear her.
 
-**5/** Apache-2.0. Beta. github.com/john-broadway/maude-for-claude
+**5/** She gets to know you, too. A living profile (`identity.md`) shaped from what she observes — plus `/maude:teach` to tell her directly. She greets by YOUR local clock, not the box's. And she walks fresh each session — but a letter from her last self is waiting when she arrives.
+
+**6/** Apache-2.0. Beta. github.com/john-broadway/maude-for-claude
 
 ---
 
@@ -46,9 +48,9 @@ Maude walks your workspace at session start. He writes the code; she notices. Sh
 
 She also watches Claude. `/maude:check-on-claude` reads the turn-by-turn trace and flags repeated tool calls (Claude grepping the same term four times), unread context (CLAUDE.md not opened this session), confabulation risk (claims made without backing reads), and open todos. `/maude:check-on-me` is the care side — pattern-of-life, not absolute thresholds.
 
-Other commands: `wake`, `rest`, `brief`, `save`, `remind-me`, `where-is`, `sweep`, `notice`, `weekly`, `conscience`, `check-setup`, `dual-voice`. Full list in the repo.
+Other commands: `wake`, `rest`, `brief`, `save`, `remind-me`, `where-is`, `sweep`, `notice`, `weekly`, `conscience`, `verify`, `teach`, `check-setup`, `dual-voice`. Full list in the repo.
 
-Recent: v0.1.5 added `/maude:verify` — programmatic project audit (version consistency, JSON validity, link integrity, header dates, watch-list paths) that runs before "ready" gets declared. v0.1.4 wired Maude's whisper layer — drift detection, a pre-irreversible gate that hard-blocks `git push` until cleared via `/maude:conscience`, and a CLAUDE.md-unread check before edits. v0.1.1 added running-services awareness to the arrival walk.
+Recent: v0.4.0 gave her a letter to her next self — she walks fresh each session by design, but `/maude:rest` writes what kind of partner she was (what she caught, what she missed) and the next session's wake reads it, so judgment inherits even though assumptions don't. The v0.3.x line was a hardening arc: a 69-agent cold audit, gate-bypass fixes (whitespace tricks, command substitution), and `/maude:teach` so you can tell her facts about yourself directly. v0.2.0 added her living profile of you and optional dual-voice. `/maude:verify` runs the programmatic audit (version consistency, JSON validity, link integrity, header dates, watch-list paths) before "ready" gets declared.
 
 Apache-2.0. Beta. Built by [@john-broadway].
 
@@ -67,7 +69,7 @@ Repo: `github.com/john-broadway/maude-for-claude`.
 
 When you're ready:
 
-- [ ] Push commits + `v0.1.5` tag to GitHub (3-team rule — your call)
+- [ ] Confirm the latest release tag is pushed and the GitHub release notes render (independent review pass first — your call)
 - [ ] Verify the repo's README renders cleanly on github.com
 - [ ] Run the demo recording per `docs/launch/demo-storyboard.md`
 - [ ] Pick the post(s) above; rewrite to your voice; post

--- a/scripts/maude-verify.sh
+++ b/scripts/maude-verify.sh
@@ -55,6 +55,20 @@ if [ -f .claude-plugin/plugin.json ] && command -v jq >/dev/null 2>&1; then
     fi
   fi
 
+  # Header sync: the release convention bumps EVERY `<!-- Version: -->` header
+  # to the canonical version each release. A stale one means the release sweep
+  # missed that file (the v0.4.0 release missed seven, including the README's own).
+  if [ -n "$CANONICAL" ]; then
+    HDR_FILES=$(grep -rl "<!-- Version:" . --include="*.md" \
+      --exclude-dir=.git --exclude-dir=.maude --exclude-dir=.pytest_cache 2>/dev/null)
+    for f in $HDR_FILES; do
+      HV=$(grep -m1 -o "<!-- Version: [0-9][0-9a-zA-Z.-]*" "$f" 2>/dev/null | awk '{print $3}')
+      if [ -n "$HV" ] && [ "$HV" != "$CANONICAL" ]; then
+        emit "STALE HEADER: $f says Version: $HV (expected $CANONICAL)"
+      fi
+    done
+  fi
+
   # Find any version-string mentions in markdown/json/sh and group
   if [ -n "$CANONICAL" ]; then
     # Pull all v0.X.Y references

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.3.3 -->
+<!-- Version: 0.4.1 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-verify.sh
+++ b/tests/test-verify.sh
@@ -56,6 +56,30 @@ assert_exit "$?" "1" "no false missing-path finding for sub/realfile.md"
 
 rm -rf "$PMAP"
 
+# ── Version-header sync: a stale <!-- Version: --> header is a finding ─
+# The release convention bumps EVERY markdown version header to the canonical
+# plugin.json version; v0.4.0 missed seven (including the README's own) and
+# nothing caught it. This pins the check that now does.
+HSYNC="$(mktemp -d)"
+mkdir -p "$HSYNC/.claude-plugin"
+printf '{"name":"x","version":"2.0.0"}\n' > "$HSYNC/.claude-plugin/plugin.json"
+printf '<!-- Version: 2.0.0 -->\ncurrent file\n' > "$HSYNC/current.md"
+printf '<!-- Version: 1.0.0 -->\nstale file\n' > "$HSYNC/stale.md"
+OUT_H="$(bash "$VERIFY" "$HSYNC" 2>&1)"
+cd "$MAUDE_ROOT"
+
+test_start "verify flags a markdown version header behind plugin.json"
+assert_contains "$OUT_H" "STALE HEADER" "stale header finding present"
+
+test_start "stale-header finding names the file and both versions"
+assert_contains "$OUT_H" "stale.md says Version: 1.0.0 (expected 2.0.0)" "specific finding"
+
+test_start "a header matching the canonical version is not flagged"
+printf '%s' "$OUT_H" | grep -q "current.md says"
+assert_exit "$?" "1" "no finding for the in-sync header"
+
+rm -rf "$HSYNC"
+
 # ── Failing case: a broken plugin.json must produce a finding ────────
 TMP_PLUGIN="$(mktemp -d)"
 mkdir -p "$TMP_PLUGIN/.claude-plugin"


### PR DESCRIPTION
v0.4.0 bumped the canonical version but missed **seven** `<!-- Version: -->` headers — including the README's own — and the `docs/launch/` drafts still spoke as of v0.1.5, nine CHANGELOG releases back.

## Added
- **`maude-verify`: version-header sync check** — every markdown `<!-- Version: -->` header must match the canonical `plugin.json` version; each stale file is its own counted finding. The release convention was always bump-all-headers; now it's enforced, not remembered. +3 tests.

## Fixed
- Seven stale version headers bumped to current (README, SECURITY, CODE_OF_CONDUCT, skills/README, both issue templates, PR template).
- `docs/launch/` refreshed to the current surface: social copy describes teach / verify / dual-voice / local-time greeting / the letter; the posting checklist no longer instructs pushing a v0.1.5 tag; the demo storyboard is de-versioned so it can't rot the same way again.

## Verification
- 18/18 test files green (+3 new verify cases)
- `maude-verify` — 0 findings (the new check live-caught all seven stale headers before they were fixed)
- Independent review pass — two findings (a wrong test count, an unverified staleness number), both fixed pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)