### PR TITLE
Maude v0.5.0 — the verify tripwire

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.4.1
+> **Version:** 0.5.0
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ the tripwire for it.
 - **`maude-verify-watch`: a commit-time verify check.** Two hooks on Bash, whisper-only,
   never blocks:
   - `stamp` (PostToolUse) records an ISO timestamp when a real test / lint / typecheck /
-    smoke run goes by — recognized at **command position only**, so `pip install pytest`,
-    `cat pytest.ini`, or a commit message that merely *names* a tool can't fake a pass. A
-    clearly-failed or interrupted run isn't counted.
+    smoke run **exits 0** — recognized at **command position** (so `pip install pytest`,
+    `cat pytest.ini` don't count) and **quote-stripped** (so a commit message that merely
+    *names* a tool can't fake a pass). A failed run, or one whose exit code isn't surfaced,
+    isn't counted.
   - `commit` (PreToolUse) whispers once — *"files changed since the last verify — did you
     check this, or are you asserting it?"* — when **code** files were edited since the last
     verify. Docs/config-only commits are suppressed; one whisper per edit-batch; the two most
@@ -30,8 +31,8 @@ the tripwire for it.
     string compare, no `date -d`). Vetted by a three-lens adversarial review before merge.
 
 ### Notes / v1 limits
-- Pass-detection is best-effort: a run is counted when the runtime doesn't expose an exit
-  code; a confirmed non-zero exit is skipped. v2 = require a proven exit 0.
+- A verify counts only on a **confirmed exit 0**; a run whose exit code the runtime doesn't
+  surface is treated as unproven and not stamped (→ a fail-loud advisory whisper).
 - Unknown/custom test-runner names aren't recognized and will draw a (one-per-batch) advisory
   whisper. Common runners across Python / JS / Rust / Go / Java / .NET / Ruby / Elixir are covered.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,41 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-11 CDT -->
+<!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.0 — the verify tripwire (2026-06-13)
+
+The gate hard-blocks irreversible *actions*. Nothing caught a confident *claim* committed
+without checking — the assert-without-verify miss, the most expensive one. This release adds
+the tripwire for it.
+
+### Added
+- **`maude-verify-watch`: a commit-time verify check.** Two hooks on Bash, whisper-only,
+  never blocks:
+  - `stamp` (PostToolUse) records an ISO timestamp when a real test / lint / typecheck /
+    smoke run goes by — recognized at **command position only**, so `pip install pytest`,
+    `cat pytest.ini`, or a commit message that merely *names* a tool can't fake a pass. A
+    clearly-failed or interrupted run isn't counted.
+  - `commit` (PreToolUse) whispers once — *"files changed since the last verify — did you
+    check this, or are you asserting it?"* — when **code** files were edited since the last
+    verify. Docs/config-only commits are suppressed; one whisper per edit-batch; the two most
+    recent trace files are read so a session crossing UTC midnight isn't blind.
+  - Timestamps only to `care.json`; no command or output content on disk. Portable (ISO
+    string compare, no `date -d`). Vetted by a three-lens adversarial review before merge.
+
+### Notes / v1 limits
+- Pass-detection is best-effort: a run is counted when the runtime doesn't expose an exit
+  code; a confirmed non-zero exit is skipped. v2 = require a proven exit 0.
+- Unknown/custom test-runner names aren't recognized and will draw a (one-per-batch) advisory
+  whisper. Common runners across Python / JS / Rust / Go / Java / .NET / Ruby / Elixir are covered.
+
+No new dependencies.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- Version: 0.5.0 -->
 <!-- Created: 2026-03-28 MST -->
-<!-- Revised: 2026-06-11 CDT -->
+<!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 
 <div align="center">
@@ -83,7 +83,7 @@ She is not loud. When she gets loud, listen.
 
 ## What's new
 
-**v0.5.0 (2026-06-13) — the verify tripwire.** The gate stops irreversible *actions*; nothing stopped a confident *claim* committed without checking. New `maude-verify-watch`: it stamps when a real test / lint / typecheck / smoke run goes by — recognized at command position, so merely *naming* a tool in a commit message can't fake a pass — and whispers once before `git commit` when **code** changed since the last verify: *"did you check this, or are you asserting it?"* Docs-only commits are suppressed; whisper-only, never blocks; timestamps only, no content on disk. Vetted by a three-lens adversarial review before merge.
+**v0.5.0 (2026-06-13) — the verify tripwire.** The gate stops irreversible *actions*; nothing stopped a confident *claim* committed without checking. New `maude-verify-watch`: it stamps when a real test / lint / typecheck / smoke run **exits 0** — recognized at command position *and* quote-stripped, so neither `pip install pytest` nor a commit message that merely *names* a tool can fake a pass — and whispers once before `git commit` when **code** changed since the last verify: *"did you check this, or are you asserting it?"* Docs-only commits are suppressed; whisper-only, never blocks; timestamps only, no content on disk. Vetted by a three-lens adversarial review before merge.
 
 **v0.4.1 (2026-06-11) — doc-sync pass.** v0.4.0 missed seven `<!-- Version: -->` headers (including this README's own) and the `docs/launch/` drafts still spoke as of v0.1.5 — nine CHANGELOG releases back. All fixed — and `maude-verify` now has a **version-header sync check**, so a stale header is a counted finding instead of something a human has to feel. The release convention was always bump-all-headers; now it's enforced, not remembered.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-11 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.5.0 (2026-06-13) — the verify tripwire.** The gate stops irreversible *actions*; nothing stopped a confident *claim* committed without checking. New `maude-verify-watch`: it stamps when a real test / lint / typecheck / smoke run goes by — recognized at command position, so merely *naming* a tool in a commit message can't fake a pass — and whispers once before `git commit` when **code** changed since the last verify: *"did you check this, or are you asserting it?"* Docs-only commits are suppressed; whisper-only, never blocks; timestamps only, no content on disk. Vetted by a three-lens adversarial review before merge.
 
 **v0.4.1 (2026-06-11) — doc-sync pass.** v0.4.0 missed seven `<!-- Version: -->` headers (including this README's own) and the `docs/launch/` drafts still spoke as of v0.1.5 — nine CHANGELOG releases back. All fixed — and `maude-verify` now has a **version-header sync check**, so a stale header is a counted finding instead of something a human has to feel. The release convention was always bump-all-headers; now it's enforced, not remembered.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -65,6 +65,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-bash-watch.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-verify-watch.sh commit",
+            "timeout": 5
           }
         ]
       }
@@ -76,6 +81,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-post-tool-use.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-verify-watch.sh stamp",
             "timeout": 5
           }
         ]

--- a/hooks/scripts/maude-verify-watch.sh
+++ b/hooks/scripts/maude-verify-watch.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Maude verify-watch hook — closes the assert-without-verify gap.
+#
+# The existing gate hard-blocks irreversible *actions*. Nothing caught a confident
+# *claim* committed without checking — Claude's #1 documented failure mode. This
+# hook is that tripwire.
+#
+# Two modes (dispatched by $1, mirroring maude-trace.sh):
+#
+#   stamp   (PostToolUse · Bash) — if the command that just ran was a verify
+#           (test / lint / typecheck / smoke), record an ISO timestamp in
+#           care.json `.last_verify_iso`. Best-effort pass detection: skips on a
+#           clearly-failed or interrupted run. Silent. Never blocks.
+#
+#   commit  (PreToolUse · Bash) — if the command is `git commit`, look at the two
+#           most recent trace files (today + the one before, so a session that
+#           crosses UTC midnight isn't blind) for file edits made *since* the last
+#           verify. If at least one such edit was a CODE file (docs/config-only
+#           commits are suppressed), whisper one line. Once per edit-batch.
+#
+# Design notes / v1 limits:
+#   * Quote-stripped before matching (like gate/bash-watch) so a commit message
+#     or `echo` that merely NAMES a tool can't be mistaken for running it.
+#   * Verify tokens must sit at COMMAND position (line start / after a shell
+#     separator / after a known run-wrapper) — so `pip install pytest`,
+#     `cat pytest.ini`, `which tsc` do NOT count as a verify.
+#   * Timestamps are compared as ISO-8601 UTC strings (lexical == chronological),
+#     so there is NO `date -d` dependency — portable to macOS/BSD.
+#   * Pass-detection is best-effort: if the runtime doesn't expose an exit code,
+#     a run is counted as a verify ("ran"), not proven-passed. A failing test in
+#     an unknown response shape could therefore suppress one whisper. v2 = require
+#     a confirmed exit 0. Acceptable for a non-blocking advisory.
+#   * Custom/unknown test runners (project-specific names) won't be recognized and
+#     will produce a (one-per-batch) advisory whisper — inherent to static matching.
+#
+# Privacy: writes ONLY timestamps to care.json. Never persists command or output
+# content to disk (consistent with maude-trace.sh's metadata-only rule).
+#
+# Always exits 0. Requires jq; silently inert without it (the SessionStart notice
+# already tells the user the hooks are degraded when jq is missing).
+
+set +e
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/_maude-common.sh"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+MODE="${1:-}"
+INPUT="$(cat 2>/dev/null)"
+[ -z "$INPUT" ] && exit 0
+
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // ""' 2>/dev/null)"
+[ -z "$CMD" ] && exit 0
+# Strip paired quotes first (same as gate/bash-watch): a commit message or echo
+# that merely names a test tool must not be read as running one.
+CMD="$(maude_strip_quotes "$CMD")"
+
+# --- pattern building blocks ------------------------------------------------
+# Command position: line start, after a shell separator, optionally after a run-
+# wrapper (sudo / env VAR= / uv|poetry|pipenv|pdm run / npx / pnpm exec / bunx).
+SEP='(^|[;&|]|&&|\|\|)[[:space:]]*'
+WRAP='((env|sudo|time|nice|xvfb-run)[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(uv|poetry|pipenv|pdm)[[:space:]]+run[[:space:]]+|npx[[:space:]]+|pnpm[[:space:]]+(exec|dlx)[[:space:]]+|bunx[[:space:]]+)*'
+# Recognized test/lint/typecheck runners (each at command position via SEP+WRAP).
+RUNNER='(pytest|py\.test|tox|nox|bats|phpunit|rspec|jest|vitest|mocha|ctest|mypy|pyright|tsc|flake8|pylint|eslint|cargo[[:space:]]+(test|check|clippy)|go[[:space:]]+test|gradlew?[[:space:]]+(test|check)|mvn[[:space:]]+(test|verify)|dotnet[[:space:]]+test|bazel[[:space:]]+test|rake[[:space:]]+(spec|test)|mix[[:space:]]+test|ruff[[:space:]]+check|black[[:space:]]+--check|pre-commit[[:space:]]+run|python[0-9.]*[[:space:]]+(-m[[:space:]]+(pytest|unittest)|manage\.py[[:space:]]+test)|(npm|yarn|pnpm|bun)[[:space:]]+(run[[:space:]]+)?(test|lint|typecheck|check)|make[[:space:]]+(test|check|lint|verify))'
+# smoke/verify/run-tests scripts invoked at command position (bash/sh/./). The
+# "run" prefix on run-tests and the distinctiveness of smoke/verify keep this from
+# matching incidental names like "latest.sh".
+SCRIPT='(bash[[:space:]]+|sh[[:space:]]+|\./)([^[:space:]]*(smoke|verify)[[:alnum:]_.-]*|[^[:space:]]*run[_-]?tests?)\.(sh|bash)'
+VERIFY_RE="${SEP}${WRAP}(${RUNNER}|${SCRIPT})"
+
+# `git commit` at command position (post quote-strip).
+COMMIT_RE="${SEP}git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)"
+
+# A target path that is docs/config (not code) — used to suppress noise on
+# docs-only commits. Anything NOT matching this is treated as code (safe default).
+DOC_RE='\.(md|markdown|txt|rst|adoc|json|ya?ml|toml|cfg|conf|ini|lock|csv|tsv|svg|png|jpe?g|gif|pdf)$|(^|/)(LICENSE|COPYING|NOTICE|CHANGELOG[^/]*|AUTHORS|\.gitignore|\.gitattributes|\.editorconfig)$'
+
+maude_ensure_self_dir
+CARE="$(maude_self_dir)/care.json"
+[ -s "$CARE" ] || printf '{}\n' > "$CARE" 2>/dev/null
+jq -e . "$CARE" >/dev/null 2>&1 || printf '{}\n' > "$CARE" 2>/dev/null
+
+# Atomic same-filesystem merge into care.json (mktemp in CARE's own dir so the
+# rename is a true atomic rename, not a cross-fs cp; rm the temp on any failure).
+care_set() {
+  local tmp
+  tmp="$(mktemp "$(dirname "$CARE")/.care.XXXXXX" 2>/dev/null)" || return 0
+  if jq "$@" "$CARE" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$CARE" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  else
+    rm -f "$tmp" 2>/dev/null
+  fi
+}
+
+case "$MODE" in
+  stamp)
+    printf '%s' "$CMD" | grep -qE -- "$VERIFY_RE" || exit 0
+    # Best-effort: don't count a FAILED or interrupted verify. Field names vary
+    # across runtimes; if none is present, count it as "ran" (see header note).
+    INTERRUPTED="$(printf '%s' "$INPUT" | jq -r '.tool_response.interrupted // false' 2>/dev/null)"
+    [ "$INTERRUPTED" = "true" ] && exit 0
+    EXIT="$(printf '%s' "$INPUT" | jq -r '.tool_response.exit_code // .tool_response.exitCode // .tool_response.code // .tool_response.returncode // ""' 2>/dev/null)"
+    if [ -n "$EXIT" ] && [ "$EXIT" != "0" ] && [ "$EXIT" != "null" ]; then exit 0; fi
+    care_set --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'
+    maude_log_trace "verify" "stamped last_verify_iso"
+    ;;
+
+  commit)
+    printf '%s' "$CMD" | grep -qE -- "$COMMIT_RE" || exit 0
+
+    TRACE_DIR="$(maude_self_dir)/trace"
+    # Two most-recent trace files (today + the prior day) so an edit made before
+    # UTC midnight is still seen by a post-midnight commit. No date arithmetic.
+    FILES="$(ls -1 "$TRACE_DIR"/today-*.jsonl 2>/dev/null | sort | tail -2)"
+    [ -z "$FILES" ] && exit 0
+
+    LAST_VERIFY_ISO="$(jq -r '.last_verify_iso // ""' "$CARE" 2>/dev/null)"
+
+    # Edits since the last verify: "ts<TAB>target" lines (ISO ts string compare).
+    EDITS="$(cat $FILES 2>/dev/null | jq -r --arg vts "$LAST_VERIFY_ISO" '
+      select(.kind=="tool"
+             and (.tool=="Write" or .tool=="Edit" or .tool=="MultiEdit")
+             and .target != null
+             and (.ts > $vts))
+      | "\(.ts)\t\(.target)"' 2>/dev/null)"
+    [ -z "$EDITS" ] && exit 0   # nothing edited since the last verify
+
+    # Suppress docs/config-only commits: only whisper if at least one edited file
+    # is code (a line NOT matching DOC_RE).
+    printf '%s\n' "$EDITS" | cut -f2 | grep -qvE "$DOC_RE" || exit 0
+
+    LAST_EDIT_ISO="$(printf '%s\n' "$EDITS" | cut -f1 | sort | tail -1)"
+    WARNED_FOR="$(jq -r '.verify_warned_for // ""' "$CARE" 2>/dev/null)"
+
+    if [ "$WARNED_FOR" != "$LAST_EDIT_ISO" ]; then
+      printf 'Maude: files changed since the last verify — did you check this, or are you asserting it?\n' >&2
+      care_set --arg e "$LAST_EDIT_ISO" '.verify_warned_for = $e'
+      maude_log_trace "verify" "commit-without-verify whisper"
+    fi
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/hooks/scripts/maude-verify-watch.sh
+++ b/hooks/scripts/maude-verify-watch.sh
@@ -8,9 +8,9 @@
 # Two modes (dispatched by $1, mirroring maude-trace.sh):
 #
 #   stamp   (PostToolUse · Bash) — if the command that just ran was a verify
-#           (test / lint / typecheck / smoke), record an ISO timestamp in
-#           care.json `.last_verify_iso`. Best-effort pass detection: skips on a
-#           clearly-failed or interrupted run. Silent. Never blocks.
+#           (test / lint / typecheck / smoke) AND it exited 0, record an ISO
+#           timestamp in care.json `.last_verify_iso`. A failed run, or one whose
+#           exit code the runtime doesn't surface, is NOT stamped. Silent. Never blocks.
 #
 #   commit  (PreToolUse · Bash) — if the command is `git commit`, look at the two
 #           most recent trace files (today + the one before, so a session that
@@ -26,10 +26,10 @@
 #     `cat pytest.ini`, `which tsc` do NOT count as a verify.
 #   * Timestamps are compared as ISO-8601 UTC strings (lexical == chronological),
 #     so there is NO `date -d` dependency — portable to macOS/BSD.
-#   * Pass-detection is best-effort: if the runtime doesn't expose an exit code,
-#     a run is counted as a verify ("ran"), not proven-passed. A failing test in
-#     an unknown response shape could therefore suppress one whisper. v2 = require
-#     a confirmed exit 0. Acceptable for a non-blocking advisory.
+#   * A verify is stamped only on a CONFIRMED exit 0 (the Bash tool_response's
+#     `exit_code`). If the exit code isn't surfaced, the run is treated as
+#     unproven and not stamped — the failure direction is fail-loud (an extra
+#     advisory whisper), never a false "you're covered".
 #   * Custom/unknown test runners (project-specific names) won't be recognized and
 #     will produce a (one-per-batch) advisory whisper — inherent to static matching.
 #
@@ -58,7 +58,8 @@ CMD="$(maude_strip_quotes "$CMD")"
 
 # --- pattern building blocks ------------------------------------------------
 # Command position: line start, after a shell separator, optionally after a run-
-# wrapper (sudo / env VAR= / uv|poetry|pipenv|pdm run / npx / pnpm exec / bunx).
+# wrapper (env/sudo/time/nice/xvfb-run, a VAR= assignment, uv|poetry|pipenv|pdm
+# run, npx, pnpm exec|dlx, bunx).
 SEP='(^|[;&|]|&&|\|\|)[[:space:]]*'
 WRAP='((env|sudo|time|nice|xvfb-run)[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(uv|poetry|pipenv|pdm)[[:space:]]+run[[:space:]]+|npx[[:space:]]+|pnpm[[:space:]]+(exec|dlx)[[:space:]]+|bunx[[:space:]]+)*'
 # Recognized test/lint/typecheck runners (each at command position via SEP+WRAP).
@@ -96,12 +97,12 @@ care_set() {
 case "$MODE" in
   stamp)
     printf '%s' "$CMD" | grep -qE -- "$VERIFY_RE" || exit 0
-    # Best-effort: don't count a FAILED or interrupted verify. Field names vary
-    # across runtimes; if none is present, count it as "ran" (see header note).
-    INTERRUPTED="$(printf '%s' "$INPUT" | jq -r '.tool_response.interrupted // false' 2>/dev/null)"
-    [ "$INTERRUPTED" = "true" ] && exit 0
+    # Count only a CONFIRMED pass. The Bash tool_response carries `exit_code`
+    # when available; require it to be 0. A failed run, or one whose exit code the
+    # runtime doesn't surface, is NOT stamped — worst case is an extra advisory
+    # whisper (fail-loud), never a false "you're covered".
     EXIT="$(printf '%s' "$INPUT" | jq -r '.tool_response.exit_code // .tool_response.exitCode // .tool_response.code // .tool_response.returncode // ""' 2>/dev/null)"
-    if [ -n "$EXIT" ] && [ "$EXIT" != "0" ] && [ "$EXIT" != "null" ]; then exit 0; fi
+    [ "$EXIT" = "0" ] || exit 0
     care_set --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'
     maude_log_trace "verify" "stamped last_verify_iso"
     ;;
@@ -118,7 +119,8 @@ case "$MODE" in
     LAST_VERIFY_ISO="$(jq -r '.last_verify_iso // ""' "$CARE" 2>/dev/null)"
 
     # Edits since the last verify: "ts<TAB>target" lines (ISO ts string compare).
-    EDITS="$(cat $FILES 2>/dev/null | jq -r --arg vts "$LAST_VERIFY_ISO" '
+    EDITS="$(printf '%s\n' "$FILES" | while IFS= read -r f; do [ -n "$f" ] && cat -- "$f"; done \
+      | jq -r --arg vts "$LAST_VERIFY_ISO" '
       select(.kind=="tool"
              and (.tool=="Write" or .tool=="Edit" or .tool=="MultiEdit")
              and .target != null

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.4.1 -->
+<!-- Version: 0.5.0 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-verify-watch.sh
+++ b/tests/test-verify-watch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Tests for hooks/scripts/maude-verify-watch.sh — the assert-without-verify tripwire.
+#   stamp  (PostToolUse·Bash) records an ISO ts when a real verify runs.
+#   commit (PreToolUse·Bash) whispers once when CODE changed since the last verify.
+# Always exits 0; whisper goes to stderr.
+
+set +e
+. "$(dirname "$0")/lib.sh"
+setup_test_env
+
+VW="$HOOKS_DIR/maude-verify-watch.sh"
+
+reset_care()  { printf '{}\n' > "$(care_path)"; }
+set_care()    { printf '%s\n' "$1" > "$(care_path)"; }
+set_trace()   { : > "$(trace_path)"; for l in "$@"; do printf '%s\n' "$l" >> "$(trace_path)"; done; }
+do_stamp()    { make_bash_tool_input "$1" | bash "$VW" stamp >/dev/null 2>&1; }
+run_commit()  { make_bash_tool_input "$1" | bash "$VW" commit 2>&1 >/dev/null; }
+
+EDIT='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/foo.py"}'
+DOC='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/README.md"}'
+
+# ---- stamp: real verifies get recorded -----------------------------------
+test_start "stamp records a verify on 'pytest -q'"
+reset_care; do_stamp "pytest -q"
+assert_ne "$(read_care '.last_verify_iso')" "null" "stamped"
+
+test_start "stamp records on a wrapped verify ('uv run pytest')"
+reset_care; do_stamp "uv run pytest tests/"
+assert_ne "$(read_care '.last_verify_iso')" "null" "wrapper stamped"
+
+# ---- stamp: false positives must NOT record ------------------------------
+test_start "stamp ignores 'pip install pytest'"
+reset_care; do_stamp "pip install pytest"
+assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
+
+test_start "stamp ignores a commit message that names a tool (quote-strip)"
+reset_care; do_stamp 'git commit -m "ran pytest, all green"'
+assert_eq "$(read_care '.last_verify_iso')" "null" "quote-stripped"
+
+test_start "stamp ignores 'cat pytest.ini'"
+reset_care; do_stamp "cat pytest.ini"
+assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
+
+test_start "stamp skips a FAILED verify (exit_code 1)"
+reset_care
+jq -nc '{tool_name:"Bash",tool_input:{command:"pytest"},tool_response:{exit_code:1},hook_event_name:"PostToolUse"}' \
+  | bash "$VW" stamp >/dev/null 2>&1
+assert_eq "$(read_care '.last_verify_iso')" "null" "failed not stamped"
+
+# ---- commit: whisper when code changed since the last verify -------------
+test_start "commit whispers when code changed since verify"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+set_trace "$EDIT"
+assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "whisper"
+
+test_start "commit is silent on a docs-only change"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+set_trace "$DOC"
+assert_eq "$(run_commit 'git commit -m "x"')" "" "docs suppressed"
+
+test_start "commit is silent when the verify postdates the edit"
+set_care '{"last_verify_iso":"2026-01-01T12:00:00Z"}'
+set_trace "$EDIT"
+assert_eq "$(run_commit 'git commit -m "x"')" "" "verify covers edit"
+
+test_start "commit cooldown silences a repeat commit (one per edit-batch)"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+set_trace "$EDIT"
+run_commit 'git commit -m "x"' >/dev/null
+assert_eq "$(run_commit 'git commit -m "again"')" "" "cooldown"
+
+test_start "commit-mode is silent on a non-commit ('git status')"
+reset_care; set_trace "$EDIT"
+assert_eq "$(run_commit 'git status')" "" "not a commit"
+
+# ---- never blocks --------------------------------------------------------
+test_start "stamp exits 0 on empty stdin"
+printf '' | bash "$VW" stamp >/dev/null 2>&1
+assert_exit "$?" "0" "empty stamp"
+
+test_start "commit exits 0 on empty stdin"
+printf '' | bash "$VW" commit >/dev/null 2>&1
+assert_exit "$?" "0" "empty commit"
+
+print_summary
+teardown_test_env
+exit $FAILED

--- a/tests/test-verify-watch.sh
+++ b/tests/test-verify-watch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tests for hooks/scripts/maude-verify-watch.sh — the assert-without-verify tripwire.
-#   stamp  (PostToolUse·Bash) records an ISO ts when a real verify runs.
+#   stamp  (PostToolUse·Bash) records an ISO ts when a verify run EXITS 0.
 #   commit (PreToolUse·Bash) whispers once when CODE changed since the last verify.
 # Always exits 0; whisper goes to stderr.
 
@@ -13,65 +13,94 @@ VW="$HOOKS_DIR/maude-verify-watch.sh"
 reset_care()  { printf '{}\n' > "$(care_path)"; }
 set_care()    { printf '%s\n' "$1" > "$(care_path)"; }
 set_trace()   { : > "$(trace_path)"; for l in "$@"; do printf '%s\n' "$l" >> "$(trace_path)"; done; }
+# stamp with an explicit exit code (a real PostToolUse·Bash tool_response shape)
+do_stamp_x()  { jq -nc --arg c "$1" --argjson ec "$2" \
+                  '{tool_name:"Bash",tool_input:{command:$c},tool_response:{exit_code:$ec},hook_event_name:"PostToolUse"}' \
+                  | bash "$VW" stamp >/dev/null 2>&1; }
+# stamp with NO exit code surfaced (an unproven run)
 do_stamp()    { make_bash_tool_input "$1" | bash "$VW" stamp >/dev/null 2>&1; }
 run_commit()  { make_bash_tool_input "$1" | bash "$VW" commit 2>&1 >/dev/null; }
 
 EDIT='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/foo.py"}'
+EDIT2='{"ts":"2026-01-01T11:30:00Z","kind":"tool","tool":"Write","target":"/p/bar.py"}'
 DOC='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/README.md"}'
 
-# ---- stamp: real verifies get recorded -----------------------------------
-test_start "stamp records a verify on 'pytest -q'"
-reset_care; do_stamp "pytest -q"
+# ---- stamp: a verify that EXITS 0 is recorded ----------------------------
+test_start "stamp records a passing 'pytest -q' (exit 0)"
+reset_care; do_stamp_x "pytest -q" 0
 assert_ne "$(read_care '.last_verify_iso')" "null" "stamped"
 
-test_start "stamp records on a wrapped verify ('uv run pytest')"
-reset_care; do_stamp "uv run pytest tests/"
+test_start "stamp records a passing wrapped verify ('uv run pytest', exit 0)"
+reset_care; do_stamp_x "uv run pytest tests/" 0
 assert_ne "$(read_care '.last_verify_iso')" "null" "wrapper stamped"
 
-# ---- stamp: false positives must NOT record ------------------------------
-test_start "stamp ignores 'pip install pytest'"
-reset_care; do_stamp "pip install pytest"
+test_start "stamp records a passing SCRIPT verify ('bash run_tests.sh', exit 0)"
+reset_care; do_stamp_x "bash run_tests.sh" 0
+assert_ne "$(read_care '.last_verify_iso')" "null" "script stamped"
+
+# ---- stamp: failures / unproven runs are NOT recorded --------------------
+test_start "stamp skips a FAILED verify (exit 1)"
+reset_care; do_stamp_x "pytest" 1
+assert_eq "$(read_care '.last_verify_iso')" "null" "failed not stamped"
+
+test_start "stamp skips an UNPROVEN verify (no exit code surfaced)"
+reset_care; do_stamp "pytest"
+assert_eq "$(read_care '.last_verify_iso')" "null" "unproven not stamped"
+
+# ---- stamp: non-verify / false-positive commands never stamp -------------
+test_start "stamp ignores 'pip install pytest' (even on exit 0)"
+reset_care; do_stamp_x "pip install pytest" 0
 assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
 
 test_start "stamp ignores a commit message that names a tool (quote-strip)"
-reset_care; do_stamp 'git commit -m "ran pytest, all green"'
+reset_care; do_stamp_x 'git commit -m "ran pytest, all green"' 0
 assert_eq "$(read_care '.last_verify_iso')" "null" "quote-stripped"
 
 test_start "stamp ignores 'cat pytest.ini'"
-reset_care; do_stamp "cat pytest.ini"
+reset_care; do_stamp_x "cat pytest.ini" 0
 assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
 
-test_start "stamp skips a FAILED verify (exit_code 1)"
-reset_care
-jq -nc '{tool_name:"Bash",tool_input:{command:"pytest"},tool_response:{exit_code:1},hook_event_name:"PostToolUse"}' \
-  | bash "$VW" stamp >/dev/null 2>&1
-assert_eq "$(read_care '.last_verify_iso')" "null" "failed not stamped"
+test_start "stamp ignores a non-test script ('bash latest.sh')"
+reset_care; do_stamp_x "bash latest.sh" 0
+assert_eq "$(read_care '.last_verify_iso')" "null" "not a test script"
 
 # ---- commit: whisper when code changed since the last verify -------------
 test_start "commit whispers when code changed since verify"
-set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
-set_trace "$EDIT"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$EDIT"
 assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "whisper"
 
+test_start "commit whispers on the first commit when never verified"
+reset_care; set_trace "$EDIT"
+assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "first-commit whisper"
+
+test_start "commit whispers on a mixed code+docs batch (a doc can't mask code)"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$DOC" "$EDIT2"
+assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "mixed whisper"
+
+# ---- commit: suppressed / silent cases -----------------------------------
 test_start "commit is silent on a docs-only change"
-set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
-set_trace "$DOC"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$DOC"
 assert_eq "$(run_commit 'git commit -m "x"')" "" "docs suppressed"
 
 test_start "commit is silent when the verify postdates the edit"
-set_care '{"last_verify_iso":"2026-01-01T12:00:00Z"}'
-set_trace "$EDIT"
+set_care '{"last_verify_iso":"2026-01-01T12:00:00Z"}'; set_trace "$EDIT"
 assert_eq "$(run_commit 'git commit -m "x"')" "" "verify covers edit"
-
-test_start "commit cooldown silences a repeat commit (one per edit-batch)"
-set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
-set_trace "$EDIT"
-run_commit 'git commit -m "x"' >/dev/null
-assert_eq "$(run_commit 'git commit -m "again"')" "" "cooldown"
 
 test_start "commit-mode is silent on a non-commit ('git status')"
 reset_care; set_trace "$EDIT"
 assert_eq "$(run_commit 'git status')" "" "not a commit"
+
+# ---- commit: cooldown is one-per-batch AND re-arms on a new edit ----------
+test_start "commit cooldown silences a repeat commit (same batch)"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$EDIT"
+run_commit 'git commit -m "x"' >/dev/null
+assert_eq "$(run_commit 'git commit -m "again"')" "" "cooldown"
+
+test_start "commit whispers AGAIN after a new edit (cooldown re-arms)"
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$EDIT"
+run_commit 'git commit -m "x"' >/dev/null     # warns, sets warned_for
+set_trace "$EDIT" "$EDIT2"                     # a newer edit lands
+assert_contains "$(run_commit 'git commit -m "y"')" "asserting it" "re-whisper on new edit"
 
 # ---- never blocks --------------------------------------------------------
 test_start "stamp exits 0 on empty stdin"


### PR DESCRIPTION
## Maude v0.5.0 — the verify tripwire

The gate hard-blocks irreversible **actions**. Nothing caught a confident **claim** committed without checking — the assert-without-verify gap. This adds the tripwire.

### What's in it
New `hooks/scripts/maude-verify-watch.sh`, registered on Pre/PostToolUse·Bash. Whisper-only, never blocks.

- **`stamp`** (PostToolUse·Bash) — records an ISO timestamp when a real test / lint / typecheck / smoke run goes by. Recognized at **command position** and **quote-stripped**, so `pip install pytest`, `cat pytest.ini`, or a commit message that merely *names* a tool can't fake a pass. A clearly-failed or interrupted run isn't counted.
- **`commit`** (PreToolUse·Bash) — whispers once before `git commit` when **code** files changed since the last verify: *"files changed since the last verify — did you check this, or are you asserting it?"* Docs/config-only commits are suppressed; one whisper per edit-batch; reads the two latest trace files so a session crossing UTC midnight isn't blind.
- Timestamps only to `care.json` — **no command or output content on disk** (consistent with the trace's metadata-only rule). Portable: ISO string compare, **no GNU-only `date -d`**.

### Quality
- Vetted by a **three-lens adversarial review** (bash correctness/portability, silent-failure, UX/false-positives). Every blocker/high fixed: quote-strip, command-position anchoring, macOS portability, docs-suppression, `mktemp` atomicity, broadened runners (Py/JS/Rust/Go/Java/.NET/Ruby/Elixir).
- New suite test `tests/test-verify-watch.sh` — **`make test` 19/19**.
- **`make verify` 0 findings** (version-header sync + README freshness).
- Version **0.4.1 → 0.5.0** across all pinned headers + CHANGELOG. Leak-audited.

### Known v1 limits
- Pass-detection is best-effort: a run is counted when the runtime doesn't expose an exit code; a confirmed non-zero exit is skipped. v2 = require a proven exit 0.
- Custom/unknown test-runner names aren't recognized and will draw a (one-per-batch) advisory whisper.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
