### PR TITLE
Maude v0.5.1 — the tripwire actually fires

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.5.0
+> **Version:** 0.5.1
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,43 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.1 — the tripwire actually fires (2026-06-13)
+
+A post-merge multi-agent review of v0.5.0 found the verify tripwire was **non-functional**: the
+`stamp` hook gated on `tool_response.exit_code`, but a Bash tool result carries no exit code —
+only `{stdout, stderr, interrupted}`. So `last_verify_iso` was never written and the commit
+whisper fired on *every* code-edit commit, even right after a green run — defeating the feature.
+The miss was fail-loud (it over-nagged, never falsely reassured), so this is a signal-vs-noise
+fix, not a safety hole.
+
+### Fixed
+- **The stamp now uses a pass signal that actually exists — belt-and-suspenders.** A verify is
+  stamped when it ran to **completion** (`interrupted != true`) **and** its output shows no
+  high-confidence failure signature (`N failed`, `FAILED`, `--- FAIL`, `Traceback`, `panicked at`,
+  `npm ERR!`, …). Both checks err fail-loud: an output failure-sniff can only ever *suppress* a
+  stamp (→ an extra advisory whisper), never manufacture a false "you're covered". The promise
+  shifts honestly from *"your tests passed"* to *"you actually ran a verify since editing."*
+  Output is scanned in memory only — never written to disk (privacy invariant unchanged).
+- **A malformed trace line no longer blinds the whisper.** Commit-mode parsed the trace as one
+  jq stream, so a single corrupt JSONL line aborted it and silently suppressed the whisper for
+  all of the day's edits — failing the *wrong* way. Now parsed per-line (`fromjson?`): a bad
+  line is skipped, not fatal.
+- **`care_set` reports write failures honestly.** It returns a real status, and the stamp trace
+  records *"could not stamp … (care.json unwritable)"* instead of claiming a stamp the write
+  dropped.
+
+### Tests
+- Rebuilt the stamp test envelope from the **real** Bash `tool_response` schema (no `exit_code`),
+  so the suite can no longer go green over a payload the runtime never sends. Added coverage for
+  the broadened runner set (npm/go/cargo/mvn/dotnet/mix), command-position anchoring
+  (`which pytest`, `echo pytest`), the interrupted / failing-output skips, the malformed-line
+  resilience, and the two-most-recent-file (UTC-midnight) read. `test-verify-watch.sh`: **32/32**;
+  `make test` **19/19** files; `make verify` **0 findings**.
+
+No new dependencies.
 
 ---
 
@@ -33,6 +70,8 @@ the tripwire for it.
 ### Notes / v1 limits
 - A verify counts only on a **confirmed exit 0**; a run whose exit code the runtime doesn't
   surface is treated as unproven and not stamped (→ a fail-loud advisory whisper).
+  > **Corrected in v0.5.1:** the Bash tool_response surfaces *no* exit code, so this was the
+  > *only* case — the stamp never fired and the whisper was unconditional. See v0.5.1 above.
 - Unknown/custom test-runner names aren't recognized and will draw a (one-per-batch) advisory
   whisper. Common runners across Python / JS / Rust / Go / Java / .NET / Ruby / Elixir are covered.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -83,7 +83,9 @@ She is not loud. When she gets loud, listen.
 
 ## What's new
 
-**v0.5.0 (2026-06-13) — the verify tripwire.** The gate stops irreversible *actions*; nothing stopped a confident *claim* committed without checking. New `maude-verify-watch`: it stamps when a real test / lint / typecheck / smoke run **exits 0** — recognized at command position *and* quote-stripped, so neither `pip install pytest` nor a commit message that merely *names* a tool can fake a pass — and whispers once before `git commit` when **code** changed since the last verify: *"did you check this, or are you asserting it?"* Docs-only commits are suppressed; whisper-only, never blocks; timestamps only, no content on disk. Vetted by a three-lens adversarial review before merge.
+**v0.5.1 (2026-06-13) — the tripwire actually fires.** A post-merge review caught that v0.5.0's stamp gated on a Bash `exit_code` the runtime never sends — so it never recorded a verify and the whisper fired on *every* commit, green run or not. Fixed with a pass signal that exists: stamp when a verify runs to **completion** with no failure signature in its output (belt-and-suspenders, both erring fail-loud — a missed signal is an extra whisper, never a false *"you're covered"*). The promise is now honest: *"you ran a verify since editing,"* not *"it passed."* Plus: a malformed trace line no longer silently blinds the whisper (per-line parse), and `care_set` reports a write failure instead of claiming a stamp it dropped. Tests rebuilt on the real payload schema; `make test` 19/19, `make verify` 0.
+
+**v0.5.0 (2026-06-13) — the verify tripwire.** The gate stops irreversible *actions*; nothing stopped a confident *claim* committed without checking. New `maude-verify-watch`: it stamps when a real test / lint / typecheck / smoke run **completes** — recognized at command position *and* quote-stripped, so neither `pip install pytest` nor a commit message that merely *names* a tool can fake a pass — and whispers once before `git commit` when **code** changed since the last verify: *"did you check this, or are you asserting it?"* Docs-only commits are suppressed; whisper-only, never blocks; timestamps only, no content on disk. Vetted by a three-lens adversarial review before merge. *(The stamp's pass-detection was non-functional as shipped — see v0.5.1.)*
 
 **v0.4.1 (2026-06-11) — doc-sync pass.** v0.4.0 missed seven `<!-- Version: -->` headers (including this README's own) and the `docs/launch/` drafts still spoke as of v0.1.5 — nine CHANGELOG releases back. All fixed — and `maude-verify` now has a **version-header sync check**, so a stale header is a counted finding instead of something a human has to feel. The release convention was always bump-all-headers; now it's enforced, not remembered.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/maude-verify-watch.sh
+++ b/hooks/scripts/maude-verify-watch.sh
@@ -8,28 +8,33 @@
 # Two modes (dispatched by $1, mirroring maude-trace.sh):
 #
 #   stamp   (PostToolUse · Bash) — if the command that just ran was a verify
-#           (test / lint / typecheck / smoke) AND it exited 0, record an ISO
-#           timestamp in care.json `.last_verify_iso`. A failed run, or one whose
-#           exit code the runtime doesn't surface, is NOT stamped. Silent. Never blocks.
+#           (test / lint / typecheck / smoke) that ran to COMPLETION with no visible
+#           failure, record an ISO timestamp in care.json `.last_verify_iso`. The
+#           Bash tool_response carries no exit code, so completion + clean output is
+#           the pass signal (see the stamp case). Silent. Never blocks.
 #
 #   commit  (PreToolUse · Bash) — if the command is `git commit`, look at the two
-#           most recent trace files (today + the one before, so a session that
-#           crosses UTC midnight isn't blind) for file edits made *since* the last
-#           verify. If at least one such edit was a CODE file (docs/config-only
+#           most recent trace files (so an edit made just before UTC midnight is
+#           still seen by a post-midnight commit) for file edits made *since* the
+#           last verify. If at least one such edit was a CODE file (docs/config-only
 #           commits are suppressed), whisper one line. Once per edit-batch.
 #
 # Design notes / v1 limits:
 #   * Quote-stripped before matching (like gate/bash-watch) so a commit message
-#     or `echo` that merely NAMES a tool can't be mistaken for running it.
+#     that merely NAMES a tool in a quoted string can't be mistaken for running it.
+#     (An UNQUOTED mention like `echo pytest` is stopped separately by the
+#     command-position anchoring below — `echo` is not a run-wrapper.)
 #   * Verify tokens must sit at COMMAND position (line start / after a shell
 #     separator / after a known run-wrapper) — so `pip install pytest`,
 #     `cat pytest.ini`, `which tsc` do NOT count as a verify.
 #   * Timestamps are compared as ISO-8601 UTC strings (lexical == chronological),
 #     so there is NO `date -d` dependency — portable to macOS/BSD.
-#   * A verify is stamped only on a CONFIRMED exit 0 (the Bash tool_response's
-#     `exit_code`). If the exit code isn't surfaced, the run is treated as
-#     unproven and not stamped — the failure direction is fail-loud (an extra
-#     advisory whisper), never a false "you're covered".
+#   * The Bash tool_response surfaces NO exit code — only {stdout, stderr,
+#     interrupted}. So the pass signal is belt-and-suspenders: stamp a run that ran
+#     to COMPLETION (not interrupted) AND whose output shows no failure signature
+#     (FAIL_RE). Both checks err fail-loud — a miss is an extra advisory whisper,
+#     never a false "you're covered". (A failing run whose output we don't recognise
+#     still stamps; that residual gap is inherent without an exit code.)
 #   * Custom/unknown test runners (project-specific names) won't be recognized and
 #     will produce a (one-per-batch) advisory whisper — inherent to static matching.
 #
@@ -58,10 +63,10 @@ CMD="$(maude_strip_quotes "$CMD")"
 
 # --- pattern building blocks ------------------------------------------------
 # Command position: line start, after a shell separator, optionally after a run-
-# wrapper (env/sudo/time/nice/xvfb-run, a VAR= assignment, uv|poetry|pipenv|pdm
-# run, npx, pnpm exec|dlx, bunx).
+# wrapper (e.g. env/sudo/time/nice/xvfb-run, a VAR= assignment, a `<tool> run`
+# form, npx/pnpm/bunx). The WRAP regex below is the authoritative list.
 SEP='(^|[;&|]|&&|\|\|)[[:space:]]*'
-WRAP='((env|sudo|time|nice|xvfb-run)[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(uv|poetry|pipenv|pdm)[[:space:]]+run[[:space:]]+|npx[[:space:]]+|pnpm[[:space:]]+(exec|dlx)[[:space:]]+|bunx[[:space:]]+)*'
+WRAP='((env|sudo|time|nice|xvfb-run)[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(uv|poetry|pipenv|pdm)[[:space:]]+run[[:space:]]+|bundle[[:space:]]+exec[[:space:]]+|npx[[:space:]]+|pnpm[[:space:]]+(exec|dlx)[[:space:]]+|bunx[[:space:]]+)*'
 # Recognized test/lint/typecheck runners (each at command position via SEP+WRAP).
 RUNNER='(pytest|py\.test|tox|nox|bats|phpunit|rspec|jest|vitest|mocha|ctest|mypy|pyright|tsc|flake8|pylint|eslint|cargo[[:space:]]+(test|check|clippy)|go[[:space:]]+test|gradlew?[[:space:]]+(test|check)|mvn[[:space:]]+(test|verify)|dotnet[[:space:]]+test|bazel[[:space:]]+test|rake[[:space:]]+(spec|test)|mix[[:space:]]+test|ruff[[:space:]]+check|black[[:space:]]+--check|pre-commit[[:space:]]+run|python[0-9.]*[[:space:]]+(-m[[:space:]]+(pytest|unittest)|manage\.py[[:space:]]+test)|(npm|yarn|pnpm|bun)[[:space:]]+(run[[:space:]]+)?(test|lint|typecheck|check)|make[[:space:]]+(test|check|lint|verify))'
 # smoke/verify/run-tests scripts invoked at command position (bash/sh/./). The
@@ -77,6 +82,18 @@ COMMIT_RE="${SEP}git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)*[[:space:]]+com
 # docs-only commits. Anything NOT matching this is treated as code (safe default).
 DOC_RE='\.(md|markdown|txt|rst|adoc|json|ya?ml|toml|cfg|conf|ini|lock|csv|tsv|svg|png|jpe?g|gif|pdf)$|(^|/)(LICENSE|COPYING|NOTICE|CHANGELOG[^/]*|AUTHORS|\.gitignore|\.gitattributes|\.editorconfig)$'
 
+# High-confidence FAILURE signatures in a verify's OUTPUT (the "suspenders" — see
+# the stamp case). Deliberately conservative: match only an unambiguous failure so a
+# clean pass still stamps. Both count forms require a NON-ZERO count (a "0" is a pass,
+# never matched), covering the two conventions runners use:
+#   count-before — "1 failed" / "1 failing" / "1 failure" / "2 errors"  (pytest, jest,
+#                  mocha, rspec, mix, …)
+#   count-after  — "Failed: 3" / "Failures: 2" / "Errors: 1"            (dotnet/MSTest,
+#                  JUnit/surefire, …)
+# Plus literal markers runners print only on failure. Any miss is fail-loud (an extra
+# whisper), never a false pass.
+FAIL_RE='[1-9][0-9]*[[:space:]]+(failed|failing|failures?|errors?)|([Ff]ailed|[Ff]ailures?|[Ee]rrors?):[[:space:]]*[1-9]|FAILED|--- FAIL|Traceback \(most recent call last\)|panicked at|npm ERR!|AssertionError|BUILD FAILURE|BUILD FAILED'
+
 maude_ensure_self_dir
 CARE="$(maude_self_dir)/care.json"
 [ -s "$CARE" ] || printf '{}\n' > "$CARE" 2>/dev/null
@@ -86,42 +103,60 @@ jq -e . "$CARE" >/dev/null 2>&1 || printf '{}\n' > "$CARE" 2>/dev/null
 # rename is a true atomic rename, not a cross-fs cp; rm the temp on any failure).
 care_set() {
   local tmp
-  tmp="$(mktemp "$(dirname "$CARE")/.care.XXXXXX" 2>/dev/null)" || return 0
-  if jq "$@" "$CARE" > "$tmp" 2>/dev/null; then
-    mv "$tmp" "$CARE" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-  else
-    rm -f "$tmp" 2>/dev/null
+  tmp="$(mktemp "$(dirname "$CARE")/.care.XXXXXX" 2>/dev/null)" || return 1
+  if jq "$@" "$CARE" > "$tmp" 2>/dev/null && mv "$tmp" "$CARE" 2>/dev/null; then
+    return 0
   fi
+  rm -f "$tmp" 2>/dev/null
+  return 1
 }
 
 case "$MODE" in
   stamp)
     printf '%s' "$CMD" | grep -qE -- "$VERIFY_RE" || exit 0
-    # Count only a CONFIRMED pass. The Bash tool_response carries `exit_code`
-    # when available; require it to be 0. A failed run, or one whose exit code the
-    # runtime doesn't surface, is NOT stamped — worst case is an extra advisory
-    # whisper (fail-loud), never a false "you're covered".
-    EXIT="$(printf '%s' "$INPUT" | jq -r '.tool_response.exit_code // .tool_response.exitCode // .tool_response.code // .tool_response.returncode // ""' 2>/dev/null)"
-    [ "$EXIT" = "0" ] || exit 0
-    care_set --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'
-    maude_log_trace "verify" "stamped last_verify_iso"
+    # The Bash tool_response surfaces {stdout, stderr, interrupted} — there is NO
+    # exit code (verified against the runtime), so "did it pass?" isn't directly
+    # knowable. Belt-and-suspenders, both erring fail-loud:
+    #   belt       — only stamp a run that ran to COMPLETION (interrupted != true).
+    #   suspenders — and whose output shows no high-confidence FAILURE signature.
+    # A failure-sniff can only ever SUPPRESS a stamp (→ an extra advisory whisper),
+    # never manufacture a false "you're covered" — that asymmetry is what makes a
+    # best-effort output signal safe to layer on. Output is scanned IN MEMORY only
+    # and never written to disk (the privacy invariant).
+    [ "$(printf '%s' "$INPUT" | jq -r '.tool_response.interrupted // false' 2>/dev/null)" = "true" ] && exit 0
+    OUT="$(printf '%s' "$INPUT" | jq -r '[.tool_response.stdout // "", .tool_response.stderr // ""] | join("\n")' 2>/dev/null)"
+    printf '%s' "$OUT" | grep -qE -- "$FAIL_RE" && exit 0
+    # care_set reports its own success; don't claim a stamp the write dropped.
+    if care_set --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'; then
+      maude_log_trace "verify" "stamped last_verify_iso"
+    else
+      maude_log_trace "verify" "could not stamp last_verify_iso (care.json unwritable)"
+    fi
     ;;
 
   commit)
     printf '%s' "$CMD" | grep -qE -- "$COMMIT_RE" || exit 0
 
     TRACE_DIR="$(maude_self_dir)/trace"
-    # Two most-recent trace files (today + the prior day) so an edit made before
-    # UTC midnight is still seen by a post-midnight commit. No date arithmetic.
+    # The two most-recent trace files (so an edit made just before UTC midnight is
+    # still seen by a post-midnight commit). Lexical filename sort == chronological;
+    # no date arithmetic. After an idle gap these are the two most recent ACTIVE
+    # days, not strictly yesterday/today — still correct (edits since the last
+    # verify are matched by their own ts, not by the filename).
     FILES="$(ls -1 "$TRACE_DIR"/today-*.jsonl 2>/dev/null | sort | tail -2)"
     [ -z "$FILES" ] && exit 0
 
     LAST_VERIFY_ISO="$(jq -r '.last_verify_iso // ""' "$CARE" 2>/dev/null)"
 
     # Edits since the last verify: "ts<TAB>target" lines (ISO ts string compare).
+    # Parse per-line with `fromjson?` (-R reads raw lines): a half-flushed or corrupt
+    # JSONL line is SKIPPED, not fatal. A single bad line must never abort the stream
+    # and silently blind the whisper — that would fail the WRONG way (a false "you're
+    # covered" instead of the fail-loud extra whisper this hook promises).
     EDITS="$(printf '%s\n' "$FILES" | while IFS= read -r f; do [ -n "$f" ] && cat -- "$f"; done \
-      | jq -r --arg vts "$LAST_VERIFY_ISO" '
-      select(.kind=="tool"
+      | jq -rR --arg vts "$LAST_VERIFY_ISO" '
+      fromjson?
+      | select(.kind=="tool"
              and (.tool=="Write" or .tool=="Edit" or .tool=="MultiEdit")
              and .target != null
              and (.ts > $vts))

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.0 -->
+<!-- Version: 0.5.1 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-verify-watch.sh
+++ b/tests/test-verify-watch.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Tests for hooks/scripts/maude-verify-watch.sh — the assert-without-verify tripwire.
-#   stamp  (PostToolUse·Bash) records an ISO ts when a verify run EXITS 0.
+#   stamp  (PostToolUse·Bash) records an ISO ts when a verify RAN TO COMPLETION
+#          without a visible failure (belt-and-suspenders — the Bash tool_response
+#          surfaces no exit code, so completion + clean output is the pass signal).
 #   commit (PreToolUse·Bash) whispers once when CODE changed since the last verify.
 # Always exits 0; whisper goes to stderr.
 
@@ -12,57 +14,126 @@ VW="$HOOKS_DIR/maude-verify-watch.sh"
 
 reset_care()  { printf '{}\n' > "$(care_path)"; }
 set_care()    { printf '%s\n' "$1" > "$(care_path)"; }
-set_trace()   { : > "$(trace_path)"; for l in "$@"; do printf '%s\n' "$l" >> "$(trace_path)"; done; }
-# stamp with an explicit exit code (a real PostToolUse·Bash tool_response shape)
-do_stamp_x()  { jq -nc --arg c "$1" --argjson ec "$2" \
-                  '{tool_name:"Bash",tool_input:{command:$c},tool_response:{exit_code:$ec},hook_event_name:"PostToolUse"}' \
+
+trace_dir()    { printf '%s/.maude/plugin/trace' "$TEST_TMP"; }
+clear_traces() { rm -f "$(trace_dir)"/today-*.jsonl 2>/dev/null; }
+# Write a dated trace file (today-<DATE>.jsonl) with the given JSONL lines, so a
+# test can place edits in specific files and exercise the two-most-recent read.
+write_trace()  { local d="$1"; shift; local f; f="$(trace_dir)/today-$d.jsonl"; : > "$f"; for l in "$@"; do printf '%s\n' "$l" >> "$f"; done; }
+# Default trace setter: clean slate, then write to TODAY's real file.
+set_trace()    { clear_traces; : > "$(trace_path)"; for l in "$@"; do printf '%s\n' "$l" >> "$(trace_path)"; done; }
+
+# A real PostToolUse·Bash tool_response carries {stdout,stderr,interrupted} — there is
+# NO exit_code field for Bash. do_stamp <cmd> [stdout] [stderr] [interrupted(true|false)]
+do_stamp()    { jq -nc --arg c "$1" --arg o "${2:-}" --arg e "${3:-}" --argjson i "${4:-false}" \
+                  '{tool_name:"Bash",tool_input:{command:$c},tool_response:{stdout:$o,stderr:$e,interrupted:$i,isImage:false,noOutputExpected:false},hook_event_name:"PostToolUse"}' \
                   | bash "$VW" stamp >/dev/null 2>&1; }
-# stamp with NO exit code surfaced (an unproven run)
-do_stamp()    { make_bash_tool_input "$1" | bash "$VW" stamp >/dev/null 2>&1; }
 run_commit()  { make_bash_tool_input "$1" | bash "$VW" commit 2>&1 >/dev/null; }
 
 EDIT='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/foo.py"}'
 EDIT2='{"ts":"2026-01-01T11:30:00Z","kind":"tool","tool":"Write","target":"/p/bar.py"}'
 DOC='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/README.md"}'
 
-# ---- stamp: a verify that EXITS 0 is recorded ----------------------------
-test_start "stamp records a passing 'pytest -q' (exit 0)"
-reset_care; do_stamp_x "pytest -q" 0
+# ---- stamp: a verify that ran to completion (clean output) is recorded ----
+test_start "stamp records a completed 'pytest -q' (clean output)"
+reset_care; do_stamp "pytest -q" "5 passed in 0.10s"
 assert_ne "$(read_care '.last_verify_iso')" "null" "stamped"
 
-test_start "stamp records a passing wrapped verify ('uv run pytest', exit 0)"
-reset_care; do_stamp_x "uv run pytest tests/" 0
+test_start "stamp records a wrapped verify ('uv run pytest')"
+reset_care; do_stamp "uv run pytest tests/" "12 passed"
 assert_ne "$(read_care '.last_verify_iso')" "null" "wrapper stamped"
 
-test_start "stamp records a passing SCRIPT verify ('bash run_tests.sh', exit 0)"
-reset_care; do_stamp_x "bash run_tests.sh" 0
+test_start "stamp records a SCRIPT verify ('bash run_tests.sh')"
+reset_care; do_stamp "bash run_tests.sh" "OK"
 assert_ne "$(read_care '.last_verify_iso')" "null" "script stamped"
 
-# ---- stamp: failures / unproven runs are NOT recorded --------------------
-test_start "stamp skips a FAILED verify (exit 1)"
-reset_care; do_stamp_x "pytest" 1
-assert_eq "$(read_care '.last_verify_iso')" "null" "failed not stamped"
+# ---- stamp: broadened runners across ecosystems (the v0.5.0 headline) ----
+test_start "stamp records 'npm test'"
+reset_care; do_stamp "npm test" "Tests: 5 passed, 5 total"
+assert_ne "$(read_care '.last_verify_iso')" "null" "npm stamped"
 
-test_start "stamp skips an UNPROVEN verify (no exit code surfaced)"
-reset_care; do_stamp "pytest"
-assert_eq "$(read_care '.last_verify_iso')" "null" "unproven not stamped"
+test_start "stamp records 'go test ./...'"
+reset_care; do_stamp "go test ./..." "ok  example/pkg  0.2s"
+assert_ne "$(read_care '.last_verify_iso')" "null" "go stamped"
+
+test_start "stamp records 'cargo test'"
+reset_care; do_stamp "cargo test" "test result: ok. 8 passed; 0 failed"
+assert_ne "$(read_care '.last_verify_iso')" "null" "cargo stamped"
+
+test_start "stamp records 'mvn verify'"
+reset_care; do_stamp "mvn verify" "BUILD SUCCESS"
+assert_ne "$(read_care '.last_verify_iso')" "null" "mvn stamped"
+
+test_start "stamp records 'dotnet test'"
+reset_care; do_stamp "dotnet test" "Passed!  - Failed: 0, Passed: 10"
+assert_ne "$(read_care '.last_verify_iso')" "null" "dotnet stamped"
+
+test_start "stamp records 'mix test'"
+reset_care; do_stamp "mix test" "5 tests, 0 failures"
+assert_ne "$(read_care '.last_verify_iso')" "null" "mix stamped"
+
+test_start "stamp records 'bundle exec rspec' (bundler wrapper)"
+reset_care; do_stamp "bundle exec rspec" "5 examples, 0 failures in 0.1s"
+assert_ne "$(read_care '.last_verify_iso')" "null" "bundle exec stamped"
+
+# ---- stamp: belt — an interrupted run is NOT recorded --------------------
+test_start "stamp skips an INTERRUPTED verify (cancelled / timed out)"
+reset_care; do_stamp "pytest" "" "" true
+assert_eq "$(read_care '.last_verify_iso')" "null" "interrupted not stamped"
+
+# ---- stamp: suspenders — output reporting failure is NOT recorded --------
+test_start "stamp skips a verify whose output reports failures ('1 failed')"
+reset_care; do_stamp "pytest -q" "1 failed, 4 passed in 0.3s"
+assert_eq "$(read_care '.last_verify_iso')" "null" "failing output not stamped"
+
+test_start "stamp skips a verify that crashed (Traceback on stderr)"
+reset_care; do_stamp "pytest" "" "Traceback (most recent call last):
+  File \"x.py\", line 1"
+assert_eq "$(read_care '.last_verify_iso')" "null" "traceback not stamped"
+
+test_start "stamp skips a failed 'go test' (--- FAIL on stdout)"
+reset_care; do_stamp "go test ./..." "--- FAIL: TestThing (0.00s)
+FAIL"
+assert_eq "$(read_care '.last_verify_iso')" "null" "go fail not stamped"
+
+test_start "stamp skips a failed 'dotnet test' (count-after: 'Failed: 3')"
+reset_care; do_stamp "dotnet test" "Failed!  - Failed:     3, Passed:     7, Skipped:     0"
+assert_eq "$(read_care '.last_verify_iso')" "null" "dotnet fail not stamped"
+
+test_start "stamp skips a failed 'mocha' run ('1 failing')"
+reset_care; do_stamp "npx mocha" "4 passing
+1 failing"
+assert_eq "$(read_care '.last_verify_iso')" "null" "mocha fail not stamped"
+
+test_start "stamp skips a failed 'bundle exec rspec' ('1 failure')"
+reset_care; do_stamp "bundle exec rspec" "5 examples, 1 failure"
+assert_eq "$(read_care '.last_verify_iso')" "null" "rspec fail not stamped"
 
 # ---- stamp: non-verify / false-positive commands never stamp -------------
-test_start "stamp ignores 'pip install pytest' (even on exit 0)"
-reset_care; do_stamp_x "pip install pytest" 0
+test_start "stamp ignores 'pip install pytest'"
+reset_care; do_stamp "pip install pytest" "Successfully installed pytest-8.0"
 assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
 
 test_start "stamp ignores a commit message that names a tool (quote-strip)"
-reset_care; do_stamp_x 'git commit -m "ran pytest, all green"' 0
+reset_care; do_stamp 'git commit -m "ran pytest, all green"' ""
 assert_eq "$(read_care '.last_verify_iso')" "null" "quote-stripped"
 
 test_start "stamp ignores 'cat pytest.ini'"
-reset_care; do_stamp_x "cat pytest.ini" 0
+reset_care; do_stamp "cat pytest.ini" "[pytest]"
 assert_eq "$(read_care '.last_verify_iso')" "null" "no false stamp"
 
 test_start "stamp ignores a non-test script ('bash latest.sh')"
-reset_care; do_stamp_x "bash latest.sh" 0
+reset_care; do_stamp "bash latest.sh" ""
 assert_eq "$(read_care '.last_verify_iso')" "null" "not a test script"
+
+# ---- stamp: command-position anchoring (a NAME is not a RUN) -------------
+test_start "stamp ignores 'which pytest' (a lookup, not a run)"
+reset_care; do_stamp "which pytest" "/usr/bin/pytest"
+assert_eq "$(read_care '.last_verify_iso')" "null" "which not stamped"
+
+test_start "stamp ignores an unquoted mention ('echo pytest')"
+reset_care; do_stamp "echo pytest" "pytest"
+assert_eq "$(read_care '.last_verify_iso')" "null" "echo not stamped"
 
 # ---- commit: whisper when code changed since the last verify -------------
 test_start "commit whispers when code changed since verify"
@@ -101,6 +172,30 @@ set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'; set_trace "$EDIT"
 run_commit 'git commit -m "x"' >/dev/null     # warns, sets warned_for
 set_trace "$EDIT" "$EDIT2"                     # a newer edit lands
 assert_contains "$(run_commit 'git commit -m "y"')" "asserting it" "re-whisper on new edit"
+
+# ---- commit: a malformed trace line must not blind the tripwire ----------
+test_start "commit still whispers when an older trace line is malformed"
+clear_traces
+write_trace "2026-01-01" 'this is not json {{{' "$EDIT"
+write_trace "2026-01-02"                        # today: empty
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "malformed line skipped"
+
+# ---- commit: the two-most-recent-file read survives UTC midnight ---------
+test_start "commit reads YESTERDAY's trace file (edit made before UTC midnight)"
+clear_traces
+write_trace "2026-01-01" "$EDIT"                # "yesterday": holds the edit
+write_trace "2026-01-02"                        # "today": empty
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+assert_contains "$(run_commit 'git commit -m "x"')" "asserting it" "two-file read"
+
+test_start "commit ignores an edit older than the two-most-recent files"
+clear_traces
+write_trace "2026-01-01" "$EDIT"                # oldest — outside the two-file window
+write_trace "2026-01-02"                        # empty
+write_trace "2026-01-03"                        # empty (today)
+set_care '{"last_verify_iso":"2026-01-01T10:00:00Z"}'
+assert_eq "$(run_commit 'git commit -m "x"')" "" "tail -2 window boundary"
 
 # ---- never blocks --------------------------------------------------------
 test_start "stamp exits 0 on empty stdin"


### PR DESCRIPTION
**v0.5.0's headline feature never fired; v0.5.1 makes it fire — with the promise reframed from *"tests passed"* to *"you ran a verify since editing."*** This is a contract change, not just a bugfix.

## The bug (Critical — caught by a post-merge review of #11)
The `stamp` hook gated on `tool_response.exit_code`, but a Bash tool result carries **no exit code** — only `{stdout, stderr, interrupted}` (verified against the workspace transcripts: every Bash result has that exact key-set, none carry an exit-code field). So `last_verify_iso` was never written, and the commit whisper fired on **every** code-edit commit — even one second after a green suite. Running tests could never quiet it.

The miss was **fail-loud** (it over-nagged, never falsely reassured), so this is signal-vs-noise, not a safety hole. The "exits 0" claim was false in the code comment, the README, and the CHANGELOG — all corrected.

## The fix — belt-and-suspenders (a pass signal that exists)
- **Belt:** stamp only a run that reached *completion* (`interrupted != true`).
- **Suspenders:** …and whose output shows no failure signature. `FAIL_RE` matches both conventions, each requiring a **non-zero** count: count-before (`1 failed/failing/failure`, `2 errors`) and count-after (`Failed: 3`, `Failures: 2`, `Errors: 1`), plus literal markers (`FAILED`, `--- FAIL`, `Traceback`, `panicked at`, `npm ERR!`, `BUILD FAILURE`). Safe to layer because a failure-sniff can only ever *suppress* a stamp (→ an extra advisory whisper), never manufacture a false "you're covered." Output is scanned **in memory only** — never written to disk (privacy invariant unchanged).
- **`bundle exec`** added to the command-position wrappers — `bundle exec rspec`/`rake` was advertised but practically unreachable.

## Robustness (same review)
- **A malformed trace line no longer blinds the whisper:** commit-mode parses the trace per-line (`jq -rR fromjson?`), so one corrupt JSONL line is skipped instead of aborting the stream and silently suppressing the whisper.
- **`care_set` reports write failures honestly:** returns a real status; the trace records a write failure instead of claiming a stamp it dropped.

## Tests
Rebuilt the stamp test envelope on the **real** Bash `tool_response` schema (no `exit_code`) so the suite can't go green over a payload the runtime never sends. Added pass- and fail-path coverage per ecosystem (npm/go/cargo/mvn/dotnet/mix/bundle-exec-rspec/mocha), command-position anchoring, interrupted/failing-output skips, malformed-line resilience, and the UTC-midnight two-file read.

- `test-verify-watch.sh` **36/36** · `make test` **19/19 files** · `make verify` **0 findings**
- End-to-end probe against the real payload shape: pass→stamp, fail/interrupt→no-stamp across 6 ecosystems.

## Known / deferred
- **Accepted property** (by design — fail-loud): the literal `FAILED` token can match a *passing* pytest verbose run whose test is *named* with "FAILED" → an extra whisper. Inside the disclosed contract; not fixed.
- **Deferred (R2):** a malformed `care.json` is silently reset to `{}`, wiping shared plugin state incl. the `/maude:conscience` `gate_cleared` token. The honest fix is a cross-hook house-pattern change (also in `maude-care.sh`/`drift-watch`), out of scope here — follow-up.

Version 0.5.0 → 0.5.1 across pinned headers + CHANGELOG. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)