### PR TITLE
Maude v0.5.2 — a wiped care.json no longer goes unrecorded (R2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,7 +21,7 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 
 ```
 .claude-plugin/
-├── plugin.json (v0.4.1)
+├── plugin.json (manifest; the canonical version)
 └── marketplace.json (single-plugin local marketplace)
 
 commands/    — 17 slash commands (markdown)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.5.1
+> **Version:** 0.5.2
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,45 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.2 — a wiped state file no longer goes unrecorded (2026-06-13)
+
+Follow-up to the v0.5.1 review (finding R2). `care.json` is the plugin's SHARED state
+(tier1 cache, the `/maude:conscience` `gate_cleared` token, cooldowns, session
+counters). When it was corrupt, hooks open-coded `jq -e . || printf '{}'` — silently
+resetting the WHOLE file to `{}` with no record. A truncated/half-written `care.json`
+(plausible after a crash) would wipe every hook's state, including a live clearance
+token, and nobody was told.
+
+### Fixed
+- **New shared `maude_care_ensure` helper** (`_maude-common.sh`): seeds `{}` when
+  `care.json` is missing/empty, and on a *corrupt* file **TRACES** the loss
+  (`"kind":"care"`) before reseeding `{}`. The state there is all transient/regenerable
+  (`gate_cleared` is a minutes-lived, fail-safe token), so reseed-not-salvage is the
+  right call — but the reset is now **recorded**, not silent. Routing init/reset through
+  one helper also stops the lossy pattern being re-copied into the next hook.
+- The two sites that did the silent wipe — `maude-care.sh` (every UserPromptSubmit) and
+  `maude-verify-watch.sh` — now call the helper.
+
+### Tests
+- `maude_care_ensure` covered for all four inputs (missing / empty / valid-preserved /
+  corrupt-reseed-and-traced). `make test` **19/19**; `make verify` **0 findings**.
+
+### Known / deferred (surfaced by the same review; intentionally not bundled here)
+- **Freeze-on-corrupt** in `maude-drift-watch.sh` and `maude-clear-gate.sh`: they only
+  init-if-missing, so a corrupt `care.json` makes their merge silently fail (state
+  frozen, not wiped). Largely theoretical — `maude-care.sh` heals the file first every
+  prompt. Routing them through the helper would fix it, but `clear-gate` writes the
+  security-sensitive `gate_cleared` token, so that shouldn't ride under an R2 banner.
+- **`maude-clear-gate.sh` reports success unconditionally**: it prints "gate cleared"
+  regardless of whether the jq write succeeded (and inits on `[ -f ]`, not `[ -s ]`), so
+  an empty/corrupt `care.json` could claim a clearance it never wrote. Fail-safe (the
+  push still blocks), but it's the same assert-without-verify pattern Maude's own
+  tripwire exists to catch — its own follow-up.
+
+No new dependencies.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.5.2 (2026-06-13) — a wiped state file no longer goes unrecorded.** Follow-up to the v0.5.1 review (R2): when the shared `care.json` was corrupt, hooks silently reset the whole file to `{}` — wiping every hook's state (incl. a live `/maude:conscience` clearance) with no record. Now a shared `maude_care_ensure` helper *traces* the loss before reseeding (the state is all transient/fail-safe, so reseed-not-salvage is right — but it's **recorded**, not silent), and routing init/reset through one helper stops the lossy pattern being re-copied. Two related findings (freeze-on-corrupt in drift/clear-gate; clear-gate claiming success without verifying its write) are flagged as deferred follow-ups.
 
 **v0.5.1 (2026-06-13) — the tripwire actually fires.** A post-merge review caught that v0.5.0's stamp gated on a Bash `exit_code` the runtime never sends — so it never recorded a verify and the whisper fired on *every* commit, green run or not. Fixed with a pass signal that exists: stamp when a verify runs to **completion** with no failure signature in its output (belt-and-suspenders, both erring fail-loud — a missed signal is an extra whisper, never a false *"you're covered"*). The promise is now honest: *"you ran a verify since editing,"* not *"it passed."* Plus: a malformed trace line no longer silently blinds the whisper (per-line parse), and `care_set` reports a write failure instead of claiming a stamp it dropped. Tests rebuilt on the real payload schema; `make test` 19/19, `make verify` 0.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -191,6 +191,33 @@ maude_ensure_user_dir() {
   mkdir -p "$(maude_user_dir)" 2>/dev/null
 }
 
+# Ensure care.json is present and a valid JSON object, RECORDING any loss.
+# care.json is the plugin's SHARED state (tier1 cache, gate_cleared, cooldowns,
+# session counters); every hook jq-MERGES its own keys into it, which needs a valid
+# base object. So:
+#   * missing or empty        → seed {}.
+#   * present but invalid JSON → TRACE the loss, then reseed {}.
+# All keys here are transient/regenerable (gate_cleared is a minutes-lived, fail-safe
+# token), so a corrupt file is reseeded rather than salvaged — but the reset is now
+# RECORDED in the trace instead of silent. (Hooks used to open-code
+# `jq -e . || printf '{}'`, which wiped the whole shared-state file with no record —
+# the R2 finding. Route care.json init/reset through here so the pattern can't be
+# silently re-copied.) jq is required to DETECT corruption; without it we only handle
+# missing/empty and leave a present file untouched (callers are inert without jq).
+# Usage: maude_care_ensure "<care.json path>"
+maude_care_ensure() {
+  local care="$1"
+  [ -n "$care" ] || return 0
+  if [ ! -s "$care" ]; then
+    printf '{}\n' > "$care" 2>/dev/null
+    return 0
+  fi
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -e . "$care" >/dev/null 2>&1 && return 0
+  maude_log_trace "care" "care.json was invalid JSON — reseeded {} (transient shared state reset)"
+  printf '{}\n' > "$care" 2>/dev/null
+}
+
 # Append a user-STATED fact to the cross-project profile (the testable core of
 # /maude:teach). Distinct from the observed-only writers (save/rest/check-on-me/
 # notice): those record what Maude inferred; this records what the user asserted,

--- a/hooks/scripts/maude-care.sh
+++ b/hooks/scripts/maude-care.sh
@@ -52,13 +52,12 @@ fi
 # so it must MERGE its 5 fields, never rewrite the file from scratch (that wiped
 # everyone else's state every prompt). Mirror probe-tier1.sh's jq-merge + atomic mv.
 if command -v jq >/dev/null 2>&1; then
-  # Seed a base object so the merge works on first run, an EMPTY file, OR a
-  # corrupt NON-EMPTY one. The old whole-file rewrite self-healed corruption every
-  # prompt; the merge must not regress that — without this reseed an invalid
-  # care.json would make every merge fail and freeze care/probe/drift/gate state
-  # forever (silently, with jq present). In the rare recovery, foreign keys are
-  # lost — acceptable: recover once vs. freeze every turn.
-  jq -e . "$CARE" >/dev/null 2>&1 || printf '{}\n' > "$CARE"
+  # Ensure a valid base object so the merge works on first run, an EMPTY file, OR a
+  # corrupt NON-EMPTY one — without this an invalid care.json would make every merge
+  # fail and freeze care/probe/drift/gate state forever (silently, with jq present).
+  # On a corrupt file the transient shared state is reset; maude_care_ensure now
+  # RECORDS that in the trace (it used to be a silent wipe — the R2 finding).
+  maude_care_ensure "$CARE"
   TMP="$(mktemp)"
   jq --arg ld "$TODAY" --arg la "$NOW" --arg ss "$SESSION_START" \
      --arg p "$PROMPTS" --arg lf "$LONG_FLAG_FIRED" \

--- a/hooks/scripts/maude-verify-watch.sh
+++ b/hooks/scripts/maude-verify-watch.sh
@@ -96,8 +96,9 @@ FAIL_RE='[1-9][0-9]*[[:space:]]+(failed|failing|failures?|errors?)|([Ff]ailed|[F
 
 maude_ensure_self_dir
 CARE="$(maude_self_dir)/care.json"
-[ -s "$CARE" ] || printf '{}\n' > "$CARE" 2>/dev/null
-jq -e . "$CARE" >/dev/null 2>&1 || printf '{}\n' > "$CARE" 2>/dev/null
+# Valid JSON base for the merge below; a corrupt file is reseeded AND traced
+# (shared helper — see maude_care_ensure; replaces the old silent wipe, R2).
+maude_care_ensure "$CARE"
 
 # Atomic same-filesystem merge into care.json (mktemp in CARE's own dir so the
 # rename is a true atomic rename, not a cross-fs cp; rm the temp on any failure).

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.1 -->
+<!-- Version: 0.5.2 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -144,6 +144,36 @@ printf '{"tier1_up":true,"tier1_last_probe":1}\n' > "$TEST_TMP/.maude/plugin/car
 maude_tier1_up
 assert_exit "$?" "1" "tier1 stale"
 
+# ── maude_care_ensure (R2: a corrupt care.json reseed must be RECORDED, not a ──
+# silent wipe of the shared-state file — tier1 cache, gate_cleared, cooldowns) ──
+CARE_E="$TEST_TMP/.maude/plugin/care.json"
+
+test_start "care_ensure seeds {} when care.json is missing"
+rm -f "$CARE_E"
+maude_care_ensure "$CARE_E"
+assert_eq "$(jq -rc . "$CARE_E" 2>/dev/null)" "{}" "missing → {}"
+
+test_start "care_ensure seeds {} when care.json is empty"
+: > "$CARE_E"
+maude_care_ensure "$CARE_E"
+assert_eq "$(jq -rc . "$CARE_E" 2>/dev/null)" "{}" "empty → {}"
+
+test_start "care_ensure PRESERVES a valid care.json (foreign keys survive)"
+printf '{"gate_cleared":{"git-push":{"until":999}},"tier1_up":true}\n' > "$CARE_E"
+maude_care_ensure "$CARE_E"
+assert_eq "$(jq -r '.gate_cleared["git-push"].until' "$CARE_E" 2>/dev/null)" "999" "valid untouched"
+
+test_start "care_ensure reseeds a CORRUPT care.json to {}"
+printf 'this is not json {{{\n' > "$CARE_E"
+maude_care_ensure "$CARE_E"
+assert_eq "$(jq -rc . "$CARE_E" 2>/dev/null)" "{}" "corrupt → {}"
+
+test_start "care_ensure RECORDS the corrupt reseed in the trace (not silent)"
+: > "$(trace_path)"
+printf 'still not json {{{\n' > "$CARE_E"
+maude_care_ensure "$CARE_E"
+assert_contains "$(cat "$(trace_path)" 2>/dev/null)" '"kind":"care"' "loss traced"
+
 # ── maude_bucket_for_hour (pure: hour int → time-of-day bucket) ───────
 test_start "bucket_for_hour 4 is night (pre-dawn)"
 assert_eq "$(maude_bucket_for_hour 4)" "night" "h=4"


### PR DESCRIPTION
**Follow-up to the v0.5.1 review (finding R2): a corrupt `care.json` used to be silently reset to `{}`, wiping every hook's shared state — now the reset is recorded.**

## The bug (R2)
`care.json` is the plugin's **shared** state: tier1 probe cache, the `/maude:conscience` `gate_cleared` token, drift/claudemd cooldowns, session counters. Hooks open-coded `jq -e . || printf '{}'` — so a corrupt file (a truncated/half-written `care.json`, plausible after a crash) was silently reset to `{}`, **wiping every hook's state including a live clearance token, with no record.** Fail-safe in direction (the gate just re-blocks), but invisible.

## The fix
- **New shared `maude_care_ensure` helper** (`_maude-common.sh`): seeds `{}` when missing/empty, and on a *corrupt* file **traces** the loss (`"kind":"care"`) before reseeding. The state there is all transient/regenerable (`gate_cleared` is a minutes-lived, fail-safe token), so reseed-not-salvage is the right call — a `.corrupt-<ts>` sidecar would just be unrecoverable baggage against the plugin's no-baggage ethos. The point is the **record**, not the bytes.
- One helper means the lossy pattern can't be silently re-copied into the next hook.
- The two **wipe** sites now call it: `maude-care.sh` (every UserPromptSubmit) and `maude-verify-watch.sh`.

## Scope kept tight to R2 (the two wipe sites)
Two related findings surfaced and are **deliberately deferred** (not bundled — changing a security gate shouldn't ride under an R2 banner):
1. **Freeze-on-corrupt** in `drift-watch` / `clear-gate` (init-only → their merge silently fails on a corrupt file; largely theoretical since `care.sh` heals it first every prompt).
2. **`clear-gate` claims "gate cleared" unconditionally** regardless of whether its write succeeded — the same assert-without-verify pattern Maude's tripwire exists to catch. (Being fixed next, separately.)

## Also (full-tree staleness sweep)
Per a "check the whole gh copy for staleness" pass: `.claude/CLAUDE.md`'s Plugin Surface comment still read `plugin.json (v0.4.1)` (two releases stale — the inline kind `make verify` can't see). De-versioned so it can't drift again. Counts re-confirmed: 17 commands, 7 lifecycle events.

## Tests
`maude_care_ensure` TDD'd across all four inputs (missing / empty / valid-preserved / corrupt-reseed-and-traced); integration probe confirms a truncated `gate_cleared` file is reset **and** traced.

- `make test` **19/19** · `make verify` **0 findings** · leak-audit clean

Version 0.5.1 → 0.5.2 across pinned headers + CHANGELOG. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)