### PR TITLE
Maude v0.5.3 — gate-clear verifies its write before claiming success

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.5.2
+> **Version:** 0.5.3
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,38 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.3 — the gate-clear no longer claims a clearance it didn't write (2026-06-13)
+
+The second of the two follow-ups flagged in v0.5.2. `maude-clear-gate.sh` (run by
+`/maude:conscience` to write a one-shot `gate_cleared` token) printed *"Maude: gate
+cleared for X"* and logged a `gate-cleared` trace **unconditionally** — even when the
+`jq` write failed (e.g. an empty or corrupt `care.json`, which it only guarded with
+`[ -f ]`, not validity). So it could tell the user the gate was open while writing
+nothing — the exact assert-without-verify pattern Maude's own tripwire exists to catch.
+Fail-safe in direction (no token written → the gate still blocks), but a false claim.
+
+### Fixed
+- `clear-gate` now heals `care.json` through the shared `maude_care_ensure` (so an
+  empty/corrupt file is repaired and the write can actually succeed), and it claims
+  success **only if the token was persisted**. On a write failure it says so on stderr
+  (*"could NOT clear the gate … the gate still stands"*), exits non-zero, and logs **no**
+  `gate-cleared` trace.
+- Hardened `maude_care_ensure` (introduced v0.5.2) to stay **silent on a reseed write
+  failure**: `printf > x 2>/dev/null` still leaks bash's redirection error (the `>` is
+  set up before `2>` applies), so an unwritable `care.json` printed a "cannot write" line
+  from a hook that must be quiet. Group-redirect (`{ …; } 2>/dev/null`) suppresses it.
+
+### Tests
+- Four failure-path tests, forcing the write to fail deterministically (even under root)
+  by making `care.json` a directory: no false "gate cleared", non-zero exit, honest
+  stderr, and no false trace. `test-clear-gate.sh` 13/13; `make test` 19/19;
+  `make verify` 0 findings.
+
+This closes both R2-adjacent follow-ups (the freeze-on-corrupt half is now moot for
+`clear-gate`, since it routes through the healing helper). No new dependencies.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.5.3 (2026-06-13) — the gate-clear no longer claims a clearance it didn't write.** The second v0.5.2 follow-up: `/maude:conscience`'s gate-clear printed *"gate cleared"* and logged the trace **unconditionally** — even when the `care.json` write failed (empty/corrupt file) — telling the user the gate was open while writing nothing. The exact assert-without-verify pattern Maude's tripwire exists to catch. Now it heals `care.json` via the shared helper and claims success **only if the token was actually persisted**; otherwise it says so on stderr, exits non-zero, and logs no trace. Fail-safe throughout (no token → the gate still blocks).
 
 **v0.5.2 (2026-06-13) — a wiped state file no longer goes unrecorded.** Follow-up to the v0.5.1 review (R2): when the shared `care.json` was corrupt, hooks silently reset the whole file to `{}` — wiping every hook's state (incl. a live `/maude:conscience` clearance) with no record. Now a shared `maude_care_ensure` helper *traces* the loss before reseeding (the state is all transient/fail-safe, so reseed-not-salvage is right — but it's **recorded**, not silent), and routing init/reset through one helper stops the lossy pattern being re-copied. Two related findings (freeze-on-corrupt in drift/clear-gate; clear-gate claiming success without verifying its write) are flagged as deferred follow-ups.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -208,14 +208,17 @@ maude_ensure_user_dir() {
 maude_care_ensure() {
   local care="$1"
   [ -n "$care" ] || return 0
+  # Group-redirect the seed so a FAILED redirection (e.g. unwritable path) is
+  # suppressed too — `printf > x 2>/dev/null` still leaks bash's redirect error
+  # because `>` is set up before `2>` applies; `{ …; } 2>/dev/null` covers it.
   if [ ! -s "$care" ]; then
-    printf '{}\n' > "$care" 2>/dev/null
+    { printf '{}\n' > "$care"; } 2>/dev/null
     return 0
   fi
   command -v jq >/dev/null 2>&1 || return 0
   jq -e . "$care" >/dev/null 2>&1 && return 0
   maude_log_trace "care" "care.json was invalid JSON — reseeded {} (transient shared state reset)"
-  printf '{}\n' > "$care" 2>/dev/null
+  { printf '{}\n' > "$care"; } 2>/dev/null
 }
 
 # Append a user-STATED fact to the cross-project profile (the testable core of

--- a/hooks/scripts/maude-clear-gate.sh
+++ b/hooks/scripts/maude-clear-gate.sh
@@ -51,14 +51,24 @@ CARE="$(maude_self_dir)/care.json"
 NOW=$(date +%s)
 UNTIL=$((NOW + DURATION))
 
-# Initialize care.json if missing
-[ -f "$CARE" ] || printf '{}\n' > "$CARE"
-
-TMP="$(mktemp 2>/dev/null)" || exit 1
-jq --arg k "$KEY" --argjson until "$UNTIL" '.gate_cleared[$k] = {until: $until}' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE"
+# Ensure a valid JSON base so the merge can succeed even if care.json was missing,
+# empty, or corrupt (shared helper — heals + records). Without this an empty/corrupt
+# file made the merge silently fail while we still claimed the gate was cleared.
+maude_care_ensure "$CARE"
 
 MINS=$((DURATION / 60))
-printf 'Maude: gate cleared for "%s" — %d minute(s). One matching command will pass, then the token clears.\n' "$KEY" "$MINS"
-maude_log_trace "gate-cleared" "key=$KEY duration=$DURATION"
+TMP="$(mktemp 2>/dev/null)" || exit 1
+# Claim success ONLY if the token was actually written — never tell the user the gate
+# is open when it isn't (a false clearance is exactly the assert-without-verify bug
+# Maude's tripwire exists to catch). The failure direction stays fail-safe: no token
+# written → the gate still blocks.
+if jq --arg k "$KEY" --argjson until "$UNTIL" '.gate_cleared[$k] = {until: $until}' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE" 2>/dev/null; then
+  printf 'Maude: gate cleared for "%s" — %d minute(s). One matching command will pass, then the token clears.\n' "$KEY" "$MINS"
+  maude_log_trace "gate-cleared" "key=$KEY duration=$DURATION"
+else
+  rm -f "$TMP" 2>/dev/null
+  printf 'Maude: could NOT clear the gate for "%s" — care.json could not be written. The gate still stands.\n' "$KEY" >&2
+  exit 1
+fi
 
 exit 0

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.2 -->
+<!-- Version: 0.5.3 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -174,6 +174,12 @@ printf 'still not json {{{\n' > "$CARE_E"
 maude_care_ensure "$CARE_E"
 assert_contains "$(cat "$(trace_path)" 2>/dev/null)" '"kind":"care"' "loss traced"
 
+test_start "care_ensure stays silent on stderr when it cannot write (no redirect leak)"
+rm -rf "$CARE_E"; mkdir -p "$CARE_E"   # an unwritable path (a directory) — reseed can't write
+err="$(maude_care_ensure "$CARE_E" 2>&1 >/dev/null)"
+rm -rf "$CARE_E"
+assert_eq "$err" "" "no stderr leak on write failure"
+
 # ── maude_bucket_for_hour (pure: hour int → time-of-day bucket) ───────
 test_start "bucket_for_hour 4 is night (pre-dawn)"
 assert_eq "$(maude_bucket_for_hour 4)" "night" "h=4"

--- a/tests/test-clear-gate.sh
+++ b/tests/test-clear-gate.sh
@@ -52,6 +52,41 @@ assert_ne "$fp" "null" "force-push present"
 test_start "git-push token still present alongside force-push"
 assert_ne "$gp" "null" "git-push present"
 
+# ── R2 follow-up: clear-gate must VERIFY its write before claiming success ──
+# It used to print "gate cleared" and log the trace UNCONDITIONALLY, even when the
+# jq write failed — the same assert-without-verify pattern Maude's own tripwire
+# catches. A write failure is forced deterministically (even under root) by making
+# care.json a DIRECTORY, so nothing can redirect-write to that path.
+force_write_fail() { rm -rf "$(care_path)"; mkdir -p "$(care_path)"; }
+undo_write_fail()  { rm -rf "$(care_path)"; }
+
+test_start "clear-gate does NOT claim success when the care.json write fails"
+force_write_fail
+OUT="$(bash "$CLEAR" git-push 2>/dev/null)"
+undo_write_fail
+assert_not_contains "$OUT" "gate cleared" "no false success"
+
+test_start "clear-gate exits non-zero when the write fails"
+force_write_fail
+bash "$CLEAR" git-push >/dev/null 2>&1
+RC=$?
+undo_write_fail
+assert_exit "$RC" "1" "write failure → exit 1"
+
+test_start "clear-gate reports the failure on stderr"
+force_write_fail
+ERR="$(bash "$CLEAR" git-push 2>&1 >/dev/null)"
+undo_write_fail
+assert_contains "$ERR" "could NOT" "honest failure message"
+
+test_start "clear-gate does NOT log a gate-cleared trace on write failure"
+: > "$(trace_path)"
+force_write_fail
+bash "$CLEAR" git-push >/dev/null 2>&1
+undo_write_fail
+n="$(count_trace_lines '.kind == "gate-cleared"')"
+assert_eq "$n" "0" "no false gate-cleared trace"
+
 print_summary
 teardown_test_env
 exit $FAILED


### PR DESCRIPTION
**Recreated from #14**, which GitHub auto-closed when #13's branch (its stacked base) was deleted on merge. Same commit, now targeting `main` directly (v0.5.2 is already merged, so this is just the v0.5.3 delta).

The second R2-adjacent follow-up: `/maude:conscience`'s gate-clear (`maude-clear-gate.sh`) printed *"gate cleared"* and logged a `gate-cleared` trace **unconditionally** — even when the `jq` write failed (empty/corrupt `care.json`, guarded only by `[ -f ]`). So it could tell the user the gate was open while writing nothing — the exact assert-without-verify pattern Maude's tripwire exists to catch. Fail-safe in direction (no token → the gate still blocks), but a false claim.

## Fix
- Heals `care.json` through the shared `maude_care_ensure` (so an empty/corrupt file is repaired and the write can succeed).
- Claims success **only if the token was persisted**; on failure → honest stderr (*"could NOT clear the gate … the gate still stands"*), non-zero exit, no `gate-cleared` trace.
- Hardened `maude_care_ensure` to stay silent on a reseed write failure (a failed `printf >` leaked past `2>/dev/null`; group-redirect suppresses it).

## Tests
Four failure-path tests, forcing the write to fail deterministically (even under root) by making `care.json` a directory: no false success, non-zero exit, honest stderr, no false trace. Plus a `care_ensure` no-stderr-leak test. `test-clear-gate.sh` 13/13 · `make test` 19/19 · `make verify` 0 · leak-audit clean.

Version 0.5.2 → 0.5.3. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)