### PR TITLE
Maude v0.5.5 — bash hardening: one care-write path + shellcheck in CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.5.4
+> **Version:** 0.5.5
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,14 @@
 # Maude for Claude — CI
 # Copyright (c) 2026 John Broadway
 # Licensed under the Apache License, Version 2.0
-# Version: 0.3.0
-# Revised: 2026-06-09 CDT — v0.3.0 sweep (audit fixes + /maude:teach)
+# Version: 0.5.5
+# Revised: 2026-06-14 CDT — v0.5.5: added shellcheck lint job
 # Authors: John Broadway, Claude (Anthropic)
 #
-# Two independent jobs run on every push and pull request to main:
+# Three independent jobs run on every push and pull request to main:
 #   - tests   : full bash test harness (make test → tests/run.sh)
 #   - verify  : programmatic project audit (make verify → scripts/maude-verify.sh)
+#   - lint    : shellcheck the shell, gated at warning severity (make lint)
 #
 # History note: v3.0 / v4.0 of this file ran a `scrub` job against a private
 # SCRUB_PATTERNS repo secret. That gate was specific to literals that no
@@ -43,3 +44,14 @@ jobs:
 
       - name: Run project audit (make verify)
         run: make verify
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify shellcheck present
+        run: shellcheck --version
+
+      - name: Lint shell scripts (make lint)
+        run: make lint

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,13 @@
+# ShellCheck config for the Maude plugin (100% bash + jq).
+# CI gates at --severity=warning (see Makefile `lint` + .github/workflows/ci.yml).
+
+# Follow `. "$DIR/_maude-common.sh"` sources so cross-file definitions resolve
+# (otherwise every hook trips SC1091 for the shared lib it sources).
+external-sources=true
+
+# The test harness asserts on a preceding test's result with the idiom
+#   [ cond ]; assert_exit "$?" ...
+# Here `$?` referring to the condition is INTENTIONAL (that's what we assert),
+# not the bug SC2319 warns about. Disabling it repo-wide keeps the test idiom
+# clean without 22 boilerplate `rc=$?` lines.
+disable=SC2319

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,45 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.5 — bash hardening: one care-write path + shellcheck in CI (2026-06-14)
+
+Internal hardening pass from a deep read of the plugin — **no behavior change** to any
+hook, just consolidation and a new lint gate. The v0.5.2–v0.5.4 shared-state findings kept
+turning up the same patterns open-coded in hook after hook; this removes the duplication so
+the next hook can't re-introduce the old footguns.
+
+### Changed
+- **One shared `maude_care_set`** (`_maude-common.sh`): the atomic, status-returning
+  `care.json` write that was open-coded as `jq … > tmp && mv` in six hooks (an SC2015
+  footgun that couldn't report failure). `care.sh`, `drift-watch`, `clear-gate`, `gate`,
+  `pre-tool-use`, and `verify-watch` now all route through it; verify-watch's local
+  `care_set` is removed. Outcomes are preserved (the full suite stays green — incl. the
+  gate's one-shot-token-consume and pre-tool's `claudemd_warned` assertions); the write
+  is now *uniformly* an atomic same-filesystem rename — a small improvement for `gate` /
+  `pre-tool-use`, which previously `mktemp`'d in `$TMPDIR` and `mv`'d cross-filesystem.
+  The "verify the write landed" discipline (v0.5.1 / v0.5.3) now lives in one place.
+- **`drift-watch` dead guards removed**: now that it heals `care.json` via
+  `maude_care_ensure` (v0.5.4), its four `[ -f "$CARE" ]` checks were always-true — gone.
+
+### Added
+- **shellcheck in CI** — `make lint` plus a third CI job, gated at `--severity=warning`
+  with a `.shellcheckrc` (follow `. _maude-common.sh` sources; one documented disable for
+  the tests' `[ cond ]; assert_exit "$?"` idiom). For a 100%-bash plugin this catches the
+  quoting / redirection / word-split class by machine — the v0.5.3 redirect-leak was found
+  by hand; the linter would now catch its kind.
+- Fixed every genuine warning the gate surfaced (declare-and-assign `SC2155`,
+  `cd … || exit` `SC2164`, `[ -o ]` → `[ ] || [ ]` `SC2166`, redirection order `SC2069`,
+  unused-var cleanups, a `source=` directive). `shellcheck --severity=warning` is clean.
+
+### Tests
+- New `maude_care_set` unit tests (write / persist / merge / failure-returns-1).
+- `make test` 19/19 · `make verify` 0 findings · `make lint` clean. The full existing
+  suite staying green is the proof the refactor preserved behavior.
+
+No new dependencies (shellcheck is a CI-runner tool, not a plugin dependency).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: test verify
+.PHONY: test verify lint
 
 test:
 	bash tests/run.sh
 
 verify:
 	bash scripts/maude-verify.sh
+
+# Lint all shell with shellcheck, gated at warning severity (see .shellcheckrc
+# for the source-following + the one intentional test-idiom disable).
+lint:
+	shellcheck --severity=warning hooks/scripts/*.sh scripts/*.sh tests/*.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.5.5 (2026-06-14) — bash hardening: one care-write path + shellcheck in CI.** A deep-read cleanup with no behavior change: the atomic `care.json` write that was copy-pasted across six hooks is now a single shared `maude_care_set` (so the "verify the write landed" discipline lives once and can't be re-forgotten), `drift-watch`'s now-redundant guards are gone, and **shellcheck** runs in CI (`make lint`, gated at warning severity) — for a 100%-bash plugin that's the machine catching the quoting/redirection class the v0.5.x reviews kept finding by hand. The full suite staying green is the proof the refactor changed nothing.
 
 **v0.5.4 (2026-06-13) — last R2 fragment + doc-staleness sweep.** Closes the loose ends: `maude-drift-watch` no longer *freezes* on a corrupt `care.json` (it now heals via the shared helper like the other state users, so its cooldown can't silently fail to persist), and a full-tree staleness pass refreshed the launch copy's "Recent:" arc to lead with the v0.5.x verify-tripwire line and de-versioned a stale `0.1.1` example in the bug-report template.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -221,6 +221,24 @@ maude_care_ensure() {
   { printf '{}\n' > "$care"; } 2>/dev/null
 }
 
+# Atomic, status-returning merge into care.json — the single write path every hook
+# shares (was open-coded as `jq … > tmp && mv` in ~6 hooks, each an SC2015 footgun
+# that couldn't report failure). mktemp in care.json's OWN dir so the rename is a
+# true same-filesystem atomic mv, never a cross-fs copy; the temp is removed on any
+# failure. Returns 0 only if the new content was persisted, 1 otherwise — so callers
+# can avoid claiming a write that didn't land (see clear-gate / verify-watch).
+# Usage: maude_care_set "<care.json path>" <jq args…> '<filter>'
+maude_care_set() {
+  local care="$1"; shift
+  local tmp
+  tmp="$(mktemp "$(dirname "$care")/.care.XXXXXX" 2>/dev/null)" || return 1
+  if jq "$@" "$care" > "$tmp" 2>/dev/null && mv "$tmp" "$care" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  return 1
+}
+
 # Append a user-STATED fact to the cross-project profile (the testable core of
 # /maude:teach). Distinct from the observed-only writers (save/rest/check-on-me/
 # notice): those record what Maude inferred; this records what the user asserted,
@@ -324,7 +342,7 @@ maude_tier1_up() {
   last_probe="$(jq -r '.tier1_last_probe // 0' "$care" 2>/dev/null)"
   up="$(jq -r '.tier1_up // false' "$care" 2>/dev/null)"
   [ "$up" = "true" ] || return 1
-  local now=$(date +%s)
+  local now; now=$(date +%s)
   [ $((now - last_probe)) -lt "$ttl" ] && return 0
   return 1
 }

--- a/hooks/scripts/maude-care.sh
+++ b/hooks/scripts/maude-care.sh
@@ -58,11 +58,9 @@ if command -v jq >/dev/null 2>&1; then
   # On a corrupt file the transient shared state is reset; maude_care_ensure now
   # RECORDS that in the trace (it used to be a silent wipe — the R2 finding).
   maude_care_ensure "$CARE"
-  TMP="$(mktemp)"
-  jq --arg ld "$TODAY" --arg la "$NOW" --arg ss "$SESSION_START" \
+  maude_care_set "$CARE" --arg ld "$TODAY" --arg la "$NOW" --arg ss "$SESSION_START" \
      --arg p "$PROMPTS" --arg lf "$LONG_FLAG_FIRED" \
-     '. + {last_date: $ld, last_active: ($la|tonumber), session_start: ($ss|tonumber), prompts_this_session: ($p|tonumber), long_flag_fired: $lf}' \
-     "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE" || rm -f "$TMP"
+     '. + {last_date: $ld, last_active: ($la|tonumber), session_start: ($ss|tonumber), prompts_this_session: ($p|tonumber), long_flag_fired: $lf}'
 else
   # No jq — leave care.json UNTOUCHED. Without a JSON parser, care can neither read
   # its own fields (the read block above is jq-gated, so the long-session nudge can

--- a/hooks/scripts/maude-clear-gate.sh
+++ b/hooks/scripts/maude-clear-gate.sh
@@ -57,16 +57,14 @@ UNTIL=$((NOW + DURATION))
 maude_care_ensure "$CARE"
 
 MINS=$((DURATION / 60))
-TMP="$(mktemp 2>/dev/null)" || exit 1
 # Claim success ONLY if the token was actually written — never tell the user the gate
 # is open when it isn't (a false clearance is exactly the assert-without-verify bug
 # Maude's tripwire exists to catch). The failure direction stays fail-safe: no token
 # written → the gate still blocks.
-if jq --arg k "$KEY" --argjson until "$UNTIL" '.gate_cleared[$k] = {until: $until}' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE" 2>/dev/null; then
+if maude_care_set "$CARE" --arg k "$KEY" --argjson until "$UNTIL" '.gate_cleared[$k] = {until: $until}'; then
   printf 'Maude: gate cleared for "%s" — %d minute(s). One matching command will pass, then the token clears.\n' "$KEY" "$MINS"
   maude_log_trace "gate-cleared" "key=$KEY duration=$DURATION"
 else
-  rm -f "$TMP" 2>/dev/null
   printf 'Maude: could NOT clear the gate for "%s" — care.json could not be written. The gate still stands.\n' "$KEY" >&2
   exit 1
 fi

--- a/hooks/scripts/maude-drift-watch.sh
+++ b/hooks/scripts/maude-drift-watch.sh
@@ -35,13 +35,11 @@ TAIL="$(tail -30 "$TRACE" | jq -c 'select(.kind == "tool")' 2>/dev/null)"
 # --- Signal 1: Grep hammering (≥4 in last 30 events) ---
 GREP_COUNT=$(printf '%s\n' "$TAIL" | jq -r 'select(.tool == "Grep") | .ts' 2>/dev/null | wc -l)
 if [ "$GREP_COUNT" -ge 4 ]; then
-  WARNED=""
-  [ -f "$CARE" ] && WARNED="$(jq -r '.drift_warned.grep // ""' "$CARE" 2>/dev/null)"
+  # care.json is guaranteed present + valid by maude_care_ensure above, so no -f guard.
+  WARNED="$(jq -r '.drift_warned.grep // ""' "$CARE" 2>/dev/null)"
   if [ "$WARNED" != "$TODAY" ]; then
     printf 'Maude: noticed Claude grepping %d times in the last 30 tool calls. He may be stuck on something — worth a sanity check.\n' "$GREP_COUNT" >&2
-    if [ -f "$CARE" ]; then
-      TMP="$(mktemp 2>/dev/null)" && jq --arg t "$TODAY" '.drift_warned.grep = $t' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE"
-    fi
+    maude_care_set "$CARE" --arg t "$TODAY" '.drift_warned.grep = $t'
     maude_log_trace "drift" "kind=grep count=$GREP_COUNT"
   fi
 fi
@@ -51,14 +49,11 @@ DUP="$(printf '%s\n' "$TAIL" | jq -r 'select(.tool == "Read" and .target != null
 if [ -n "$DUP" ]; then
   COUNT="$(printf '%s' "$DUP" | awk '{print $1}')"
   TARGET="$(printf '%s' "$DUP" | sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//')"
-  WARNED=""
-  [ -f "$CARE" ] && WARNED="$(jq -r --arg t "$TARGET" '.drift_warned.read_targets[$t] // ""' "$CARE" 2>/dev/null)"
+  WARNED="$(jq -r --arg t "$TARGET" '.drift_warned.read_targets[$t] // ""' "$CARE" 2>/dev/null)"
   if [ "$WARNED" != "$TODAY" ]; then
     BASE="$(basename "$TARGET")"
     printf 'Maude: noticed Claude has Read %s %d times today. Worth checking what he is looking for.\n' "$BASE" "$COUNT" >&2
-    if [ -f "$CARE" ]; then
-      TMP="$(mktemp 2>/dev/null)" && jq --arg t "$TARGET" --arg today "$TODAY" '.drift_warned.read_targets[$t] = $today' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE"
-    fi
+    maude_care_set "$CARE" --arg t "$TARGET" --arg today "$TODAY" '.drift_warned.read_targets[$t] = $today'
     maude_log_trace "drift" "kind=read target=$BASE count=$COUNT"
   fi
 fi

--- a/hooks/scripts/maude-gate.sh
+++ b/hooks/scripts/maude-gate.sh
@@ -96,8 +96,8 @@ CARE="$(maude_self_dir)/care.json"
 if [ -f "$CARE" ] && command -v jq >/dev/null 2>&1; then
   CLEARED_UNTIL="$(jq -r --arg k "$MATCHED_KEY" '.gate_cleared[$k].until // 0' "$CARE" 2>/dev/null)"
   if [ -n "$CLEARED_UNTIL" ] && [ "$CLEARED_UNTIL" -gt 0 ] && [ "$CLEARED_UNTIL" -gt "$NOW" ] 2>/dev/null; then
-    # Token is live — allow this one through, then clear it
-    TMP="$(mktemp 2>/dev/null)" && jq --arg k "$MATCHED_KEY" 'del(.gate_cleared[$k])' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE"
+    # Token is live — allow this one through, then consume it (atomic, shared helper)
+    maude_care_set "$CARE" --arg k "$MATCHED_KEY" 'del(.gate_cleared[$k])'
     maude_log_trace "gate" "passed=$MATCHED_KEY"
     exit 0
   fi

--- a/hooks/scripts/maude-pre-compact.sh
+++ b/hooks/scripts/maude-pre-compact.sh
@@ -25,7 +25,6 @@ REMEMBER="$PROJ/.remember"
 SELF="$(maude_self_dir)"
 
 TIME="$(date +%H:%M)"
-TODAY="$(date +%Y-%m-%d)"
 STAMP="$(date -u +%Y-%m-%dT%H%MZ)"
 SOURCED=""
 

--- a/hooks/scripts/maude-pre-tool-use.sh
+++ b/hooks/scripts/maude-pre-tool-use.sh
@@ -80,7 +80,7 @@ if command -v jq >/dev/null 2>&1; then
         printf 'Maude: about to edit %s but CLAUDE.md has not been Read this session. Worth reading the rules first.\n' "$TARGET" >&2
         SURFACED="${SURFACED}claudemd-unread "
         if [ -f "$CARE" ]; then
-          TMP="$(mktemp 2>/dev/null)" && jq --arg t "$TODAY" '.claudemd_warned = $t' "$CARE" > "$TMP" 2>/dev/null && mv "$TMP" "$CARE"
+          maude_care_set "$CARE" --arg t "$TODAY" '.claudemd_warned = $t'
         fi
       fi
     fi

--- a/hooks/scripts/maude-session-start.sh
+++ b/hooks/scripts/maude-session-start.sh
@@ -10,7 +10,6 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 PROJ="$(maude_project_dir)"
 MEM="$(maude_mem_dir)"
-SELF="$(maude_self_dir)"
 USER_DIR="$(maude_user_dir)"
 REMEMBER="$PROJ/.remember"
 MAP="$(maude_map_path)"
@@ -87,7 +86,7 @@ GREETING="$(maude_greeting)"
   [ -n "$PATTERN_HINT" ]      && printf '  Cross-project pattern: %s\n' "$PATTERN_HINT"
   [ -n "$LETTER_LINE" ]       && printf '  Letter from my last self: %s\n' "$LETTER_LINE"
   [ "$TOPIC_COUNT" -gt 0 ]    && printf '  %s memory file(s) on hand.\n' "$TOPIC_COUNT"
-  [ -z "$HAS_MAP" ] && [ -d "$REMEMBER" -o -d "$MEM" ] && printf '  No house-map yet — run /maude:found.\n'
+  [ -z "$HAS_MAP" ] && { [ -d "$REMEMBER" ] || [ -d "$MEM" ]; } && printf '  No house-map yet — run /maude:found.\n'
 } 2>/dev/null
 
 exit 0

--- a/hooks/scripts/maude-verify-watch.sh
+++ b/hooks/scripts/maude-verify-watch.sh
@@ -100,18 +100,6 @@ CARE="$(maude_self_dir)/care.json"
 # (shared helper — see maude_care_ensure; replaces the old silent wipe, R2).
 maude_care_ensure "$CARE"
 
-# Atomic same-filesystem merge into care.json (mktemp in CARE's own dir so the
-# rename is a true atomic rename, not a cross-fs cp; rm the temp on any failure).
-care_set() {
-  local tmp
-  tmp="$(mktemp "$(dirname "$CARE")/.care.XXXXXX" 2>/dev/null)" || return 1
-  if jq "$@" "$CARE" > "$tmp" 2>/dev/null && mv "$tmp" "$CARE" 2>/dev/null; then
-    return 0
-  fi
-  rm -f "$tmp" 2>/dev/null
-  return 1
-}
-
 case "$MODE" in
   stamp)
     printf '%s' "$CMD" | grep -qE -- "$VERIFY_RE" || exit 0
@@ -127,8 +115,8 @@ case "$MODE" in
     [ "$(printf '%s' "$INPUT" | jq -r '.tool_response.interrupted // false' 2>/dev/null)" = "true" ] && exit 0
     OUT="$(printf '%s' "$INPUT" | jq -r '[.tool_response.stdout // "", .tool_response.stderr // ""] | join("\n")' 2>/dev/null)"
     printf '%s' "$OUT" | grep -qE -- "$FAIL_RE" && exit 0
-    # care_set reports its own success; don't claim a stamp the write dropped.
-    if care_set --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'; then
+    # maude_care_set reports its own success; don't claim a stamp the write dropped.
+    if maude_care_set "$CARE" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_verify_iso = $ts'; then
       maude_log_trace "verify" "stamped last_verify_iso"
     else
       maude_log_trace "verify" "could not stamp last_verify_iso (care.json unwritable)"
@@ -173,7 +161,7 @@ case "$MODE" in
 
     if [ "$WARNED_FOR" != "$LAST_EDIT_ISO" ]; then
       printf 'Maude: files changed since the last verify — did you check this, or are you asserting it?\n' >&2
-      care_set --arg e "$LAST_EDIT_ISO" '.verify_warned_for = $e'
+      maude_care_set "$CARE" --arg e "$LAST_EDIT_ISO" '.verify_warned_for = $e'
       maude_log_trace "verify" "commit-without-verify whisper"
     fi
     ;;

--- a/scripts/maude-verify.sh
+++ b/scripts/maude-verify.sh
@@ -15,6 +15,7 @@ set +e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # Source common helpers if present (hooks/scripts/_maude-common.sh)
 COMMON="$DIR/../hooks/scripts/_maude-common.sh"
+# shellcheck disable=SC1090  # $COMMON is computed from $DIR; load is guarded by [ -f ]
 [ -f "$COMMON" ] && . "$COMMON"
 
 PROJ="${1:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.4 -->
+<!-- Version: 0.5.5 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -18,6 +18,7 @@ set +e
 # Find the maude project root from this lib's path: tests/lib.sh → ..
 MAUDE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOKS_DIR="$MAUDE_ROOT/hooks/scripts"
+# shellcheck disable=SC2034  # used by sourcing test files (e.g. test-verify.sh)
 SCRIPTS_DIR="$MAUDE_ROOT/scripts"
 
 PASSED=0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,7 +3,7 @@
 # Exit 0 if all pass, 1 if any fail.
 
 set +e
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 # Loud guard: most assertions read state via jq-backed helpers (read_care,
 # count_trace_lines) that return null/0 when jq is absent — which would make

--- a/tests/test-_maude-common.sh
+++ b/tests/test-_maude-common.sh
@@ -180,6 +180,26 @@ err="$(maude_care_ensure "$CARE_E" 2>&1 >/dev/null)"
 rm -rf "$CARE_E"
 assert_eq "$err" "" "no stderr leak on write failure"
 
+# ── maude_care_set (shared atomic care.json write; returns status) ──
+test_start "care_set writes a key and returns success"
+printf '{}\n' > "$CARE_E"
+maude_care_set "$CARE_E" --arg v "hi" '.foo = $v'; rc=$?
+assert_eq "$rc" "0" "returns 0 on success"
+
+test_start "care_set persisted the value"
+assert_eq "$(jq -r '.foo' "$CARE_E" 2>/dev/null)" "hi" "value written"
+
+test_start "care_set merges — preserves existing keys"
+printf '{"keep":1}\n' > "$CARE_E"
+maude_care_set "$CARE_E" --arg v "x" '.foo = $v'
+assert_eq "$(jq -r '.keep' "$CARE_E" 2>/dev/null)" "1" "existing key kept"
+
+test_start "care_set returns failure when the write can't happen"
+rm -rf "$CARE_E"; mkdir -p "$CARE_E"   # care.json is a directory → jq can't read/write it
+maude_care_set "$CARE_E" '.foo = 1'; rc=$?
+rm -rf "$CARE_E"
+assert_eq "$rc" "1" "returns 1 on write failure"
+
 # ── maude_bucket_for_hour (pure: hour int → time-of-day bucket) ───────
 test_start "bucket_for_hour 4 is night (pre-dawn)"
 assert_eq "$(maude_bucket_for_hour 4)" "night" "h=4"

--- a/tests/test-post-tool-use.sh
+++ b/tests/test-post-tool-use.sh
@@ -9,7 +9,7 @@ POST="$HOOKS_DIR/maude-post-tool-use.sh"
 
 run_post() {
   local fp="$1"
-  ERR="$(make_edit_tool_input "$fp" | bash "$POST" 2>&1 >/dev/null)"
+  make_edit_tool_input "$fp" | bash "$POST" >/dev/null 2>&1
   RC=$?
 }
 
@@ -45,7 +45,7 @@ run_post "$TEST_TMP/random.txt"
 assert_exit "$RC" "0" "exit"
 
 test_start "post-tool handles empty stdin"
-ERR="$(printf '' | bash "$POST" 2>&1 >/dev/null)"
+printf '' | bash "$POST" >/dev/null 2>&1
 RC=$?
 assert_exit "$RC" "0" "empty stdin"
 

--- a/tests/test-verify-watch.sh
+++ b/tests/test-verify-watch.sh
@@ -28,7 +28,7 @@ set_trace()    { clear_traces; : > "$(trace_path)"; for l in "$@"; do printf '%s
 do_stamp()    { jq -nc --arg c "$1" --arg o "${2:-}" --arg e "${3:-}" --argjson i "${4:-false}" \
                   '{tool_name:"Bash",tool_input:{command:$c},tool_response:{stdout:$o,stderr:$e,interrupted:$i,isImage:false,noOutputExpected:false},hook_event_name:"PostToolUse"}' \
                   | bash "$VW" stamp >/dev/null 2>&1; }
-run_commit()  { make_bash_tool_input "$1" | bash "$VW" commit 2>&1 >/dev/null; }
+run_commit()  { { make_bash_tool_input "$1" | bash "$VW" commit >/dev/null; } 2>&1; }
 
 EDIT='{"ts":"2026-01-01T11:00:00Z","kind":"tool","tool":"Edit","target":"/p/foo.py"}'
 EDIT2='{"ts":"2026-01-01T11:30:00Z","kind":"tool","tool":"Write","target":"/p/bar.py"}'

--- a/tests/test-verify.sh
+++ b/tests/test-verify.sh
@@ -48,7 +48,7 @@ cat > "$PMAP/.maude/plugin/house-map.md" <<'EOF'
 ## Notes
 EOF
 OUT_P="$(bash "$VERIFY" "$PMAP" 2>&1)"
-cd "$MAUDE_ROOT"
+cd "$MAUDE_ROOT" || exit 1
 
 test_start "watch-list parser ignores a trailing inline description"
 printf '%s' "$OUT_P" | grep -q "Watch-list path missing: sub/realfile.md"
@@ -66,7 +66,7 @@ printf '{"name":"x","version":"2.0.0"}\n' > "$HSYNC/.claude-plugin/plugin.json"
 printf '<!-- Version: 2.0.0 -->\ncurrent file\n' > "$HSYNC/current.md"
 printf '<!-- Version: 1.0.0 -->\nstale file\n' > "$HSYNC/stale.md"
 OUT_H="$(bash "$VERIFY" "$HSYNC" 2>&1)"
-cd "$MAUDE_ROOT"
+cd "$MAUDE_ROOT" || exit 1
 
 test_start "verify flags a markdown version header behind plugin.json"
 assert_contains "$OUT_H" "STALE HEADER" "stale header finding present"
@@ -86,9 +86,9 @@ mkdir -p "$TMP_PLUGIN/.claude-plugin"
 cat > "$TMP_PLUGIN/.claude-plugin/plugin.json" <<'EOF'
 { this is not valid JSON
 EOF
-OUT_B="$(bash "$VERIFY" "$TMP_PLUGIN" 2>&1)"
+bash "$VERIFY" "$TMP_PLUGIN" >/dev/null 2>&1
 RC_B=$?
-cd "$MAUDE_ROOT"
+cd "$MAUDE_ROOT" || exit 1
 
 test_start "verify exits non-zero on broken plugin.json"
 [ "$RC_B" -ne 0 ]


### PR DESCRIPTION
**Internal hardening from a deep read of the plugin — no behavior change, just consolidation and a new lint gate.** The v0.5.2–v0.5.4 reviews kept finding the same patterns open-coded in hook after hook; this removes the duplication so the next hook can't re-introduce the footguns.

## Changed
- **One shared `maude_care_set`** (`_maude-common.sh`): the atomic, status-returning `care.json` write that was open-coded as `jq … > tmp && mv` in **six** hooks (an SC2015 footgun that couldn't report failure). `care.sh`, `drift-watch`, `clear-gate`, `gate`, `pre-tool-use`, `verify-watch` now all route through it; verify-watch's local `care_set` is removed. **Outcomes preserved** — the full suite stays green, *including* the gate's one-shot-token-consume assertion (`test-gate.sh`: token → `absent`, 2nd push re-blocked) and pre-tool's `claudemd_warned` stamp assertion. The write is now *uniformly* a same-fs atomic rename — a small improvement for `gate`/`pre-tool-use`, which previously `mktemp`'d in `$TMPDIR` and `mv`'d cross-filesystem.
- **`drift-watch` dead guards removed**: now that `maude_care_ensure` (v0.5.4) guarantees the file, its four `[ -f "$CARE" ]` checks were always-true.

## Added
- **shellcheck in CI** — `make lint` + a third CI job, gated at `--severity=warning`, with a `.shellcheckrc` (`external-sources` to follow the shared lib; one documented `SC2319` disable for the tests' `[ cond ]; assert_exit "$?"` idiom). For a 100%-bash plugin this catches the quoting/redirection/word-split class by machine — the v0.5.3 redirect-leak was found *by hand*; the linter would now catch its kind.
- Fixed every genuine warning surfaced: `SC2155` (declare+assign), `SC2164` (`cd … || exit`), `SC2166` (`[ -o ]`→`[ ]||[ ]`), `SC2069` (redirection order), `SC2034` unused-var cleanups, an `SC1090` source directive.

## Verification
- `make test` **19/19** · `make verify` **0 findings** · `make lint` **clean** (local shellcheck 0.10.0) · leak-audit clean.
- New `maude_care_set` unit tests (write / persist / merge / failure-returns-1).
- ⚠️ The `lint` CI job runs the runner's shellcheck (version may differ from local) — watching it on this PR; will pin the version in-workflow if a version delta turns it red.

Version 0.5.4 → 0.5.5. No new dependencies (shellcheck is a CI tool, not a plugin dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)