### PR TITLE
Maude v0.5.6 — prune stale drift cooldowns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maude",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Maude for Claude
 
-> **Version:** 0.5.5
+> **Version:** 0.5.6
 > **License:** Apache 2.0, Copyright John Broadway
 
 ## What Maude Is

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep; tests + verify are the local gates -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,28 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.5.6 — prune stale drift cooldowns (2026-06-14)
+
+A small leak found in the v0.5.5 deep read: `care.json`'s `.drift_warned.read_targets`
+grew **one key per distinct over-read file, forever**. `drift-watch` added a dated key for
+the once-per-day "Claude keeps re-Reading X" cooldown but never removed yesterday's — so
+the shared state file accumulated dead keys over a project's life. The only monotonically-
+growing, never-self-cleaning state in the plugin.
+
+### Fixed
+- `drift-watch` now **prunes stale-dated `read_targets` keys on write**: the same atomic
+  `maude_care_set` that records today's cooldown also drops every entry whose date isn't
+  today (the cooldown only ever checks today). Behavior is unchanged — today's cooldown
+  still holds; only dead keys are reclaimed.
+
+### Tests
+- A `read_targets` prune test (stale entry pruned, same-day entry kept, new target
+  recorded). `make test` 19/19 · `make verify` 0 · `make lint` clean.
+
+No new dependencies.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-13 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -82,6 +82,8 @@ She is not loud. When she gets loud, listen.
 ---
 
 ## What's new
+
+**v0.5.6 (2026-06-14) — prune stale drift cooldowns.** A small leak the v0.5.5 deep read turned up: `care.json`'s `drift_warned.read_targets` grew one key per distinct over-read file forever (the once-per-day cooldown added dated keys but never dropped yesterday's). `drift-watch` now prunes stale-dated keys on the same write that records today's — behavior unchanged, dead keys reclaimed. It was the only monotonically-growing state left in the plugin.
 
 **v0.5.5 (2026-06-14) — bash hardening: one care-write path + shellcheck in CI.** A deep-read cleanup with no behavior change: the atomic `care.json` write that was copy-pasted across six hooks is now a single shared `maude_care_set` (so the "verify the write landed" discipline lives once and can't be re-forgotten), `drift-watch`'s now-redundant guards are gone, and **shellcheck** runs in CI (`make lint`, gated at warning severity) — for a 100%-bash plugin that's the machine catching the quoting/redirection class the v0.5.x reviews kept finding by hand. The full suite staying green is the proof the refactor changed nothing.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Revised: 2026-06-09 CDT — version-header sweep -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/hooks/scripts/maude-drift-watch.sh
+++ b/hooks/scripts/maude-drift-watch.sh
@@ -53,7 +53,11 @@ if [ -n "$DUP" ]; then
   if [ "$WARNED" != "$TODAY" ]; then
     BASE="$(basename "$TARGET")"
     printf 'Maude: noticed Claude has Read %s %d times today. Worth checking what he is looking for.\n' "$BASE" "$COUNT" >&2
-    maude_care_set "$CARE" --arg t "$TARGET" --arg today "$TODAY" '.drift_warned.read_targets[$t] = $today'
+    # Record this target's cooldown AND prune stale-dated keys in one write — the
+    # cooldown only cares about TODAY, so yesterday's entries are cruft. Without this,
+    # read_targets grew one key per distinct over-read file, forever (care.json bloat).
+    maude_care_set "$CARE" --arg t "$TARGET" --arg today "$TODAY" \
+      '.drift_warned.read_targets = ((.drift_warned.read_targets // {}) | with_entries(select(.value == $today)) + {($t): $today})'
     maude_log_trace "drift" "kind=read target=$BASE count=$COUNT"
   fi
 fi

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.5.5 -->
+<!-- Version: 0.5.6 -->
 <!-- Revised: 2026-06-09 CDT — plugin-only -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/tests/test-drift-watch.sh
+++ b/tests/test-drift-watch.sh
@@ -79,6 +79,26 @@ test_start "drift heals a corrupt care.json and persists its cooldown (no freeze
 run_drift
 assert_eq "$(read_care '.drift_warned.grep')" "$TODAY" "cooldown persisted after heal"
 
+# ── v0.5.6: read_targets prunes STALE-dated keys (no unbounded growth in care.json) ──
+# The cooldown only cares about TODAY's date, so yesterday's keys are pure cruft; a
+# write must drop them, not just append. Seed a stale entry + a same-day entry, then
+# fire a new read-drift: stale gone, today's kept, new recorded.
+clear_traces
+jq -nc --arg today "$TODAY" \
+  '{drift_warned:{read_targets:{"/old/stale.py":"2020-01-01","/today/kept.py":$today}}}' \
+  > "$(care_path)"
+seed_trace 4 "Read" "/p/newfile.md"
+run_drift
+
+test_start "drift records the newly over-read target"
+assert_ne "$(read_care '.drift_warned.read_targets["/p/newfile.md"]')" "null" "new target recorded"
+
+test_start "drift prunes a stale-dated read_targets entry (no unbounded growth)"
+assert_eq "$(read_care '.drift_warned.read_targets["/old/stale.py"]')" "null" "stale entry pruned"
+
+test_start "drift keeps a same-day read_targets entry (prune is date-scoped)"
+assert_eq "$(read_care '.drift_warned.read_targets["/today/kept.py"]')" "$TODAY" "today entry kept"
+
 print_summary
 teardown_test_env
 exit $FAILED


### PR DESCRIPTION
**A small leak the v0.5.5 deep read turned up: `care.json`'s `.drift_warned.read_targets` grew one key per distinct over-read file, forever.**

`drift-watch` adds a dated key for the once-per-day "Claude keeps re-Reading X" cooldown, but never removed yesterday's — so the shared state file accumulated dead keys over a project's life. It was the only monotonically-growing, never-self-cleaning state left in the plugin.

## Fix
- `drift-watch` now **prunes stale-dated `read_targets` keys on write**: the same atomic `maude_care_set` that records today's cooldown also drops every entry whose date isn't today (the cooldown only ever checks today). **Behavior unchanged** — today's cooldown still holds; only dead keys are reclaimed.

## Tests
- New `read_targets` prune test: stale entry pruned, same-day entry kept, new target recorded.
- `make test` **19/19** · `make verify` **0** · `make lint` **clean** · leak-audit clean.

Version 0.5.5 → 0.5.6. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)