### PR TITLE
chore(ci): de-version the ci.yml header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # Maude for Claude — CI
 # Copyright (c) 2026 John Broadway
 # Licensed under the Apache License, Version 2.0
-# Version: 0.5.5
-# Revised: 2026-06-14 CDT — v0.5.5: added shellcheck lint job
+# (De-versioned: this workflow tracks no version of its own — the canonical version
+#  lives in .claude-plugin/plugin.json. This header used to pin a number that drifted.)
+# Last substantive change: 2026-06-14 — added the shellcheck lint job (v0.5.5).
 # Authors: John Broadway, Claude (Anthropic)
 #
 # Three independent jobs run on every push and pull request to main:


### PR DESCRIPTION
The CI workflow's `# Version:` comment pinned a number that **drifted** — it sat at `0.5.5` while the plugin moved to `0.5.6`. It's the same drift-prone inline-version pattern already de-versioned in `.claude/CLAUDE.md` (v0.5.2) and `bug_report.md` (v0.5.4), and the last one left in the repo.

**Change:** drop the `# Version:` pin (the canonical version lives in `.claude-plugin/plugin.json`); keep a non-drifting "last substantive change" provenance note.

**Comment-only** — the three jobs (tests / verify / lint) are unchanged. `make test` 19/19 · `make verify` 0 · `make lint` clean. **No version bump** — this is CI infra hygiene, not a plugin release, so it carries no CHANGELOG entry or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)