### PR TITLE
feat(hooks): add maude-secret-scan UserPromptSubmit guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The Maude Claude Code plugin.
 
 ---
 
+## Unreleased
+
+### Added
+- **`maude-secret-scan` hook (UserPromptSubmit)** — scans each submitted prompt for
+  credential-shaped strings (PyPI / GitHub / AWS / Slack / OpenAI / Anthropic / Google tokens,
+  private-key blocks) and, on a match, alerts Claude to drive an immediate **revoke** — without
+  ever echoing the secret value. It is **detection + fast-revoke, not prevention**: by the time any
+  hook runs, the text the user typed is already submitted; the win is a much smaller exposure
+  window. Born after a PyPI token leaked twice via a `!` command — the `maude-gate` PreToolUse hook
+  only sees Claude's *tool calls*, not user-typed `!` lines, so this watches the input surface
+  instead. Never blocks; tuned so prose mentions of tokens don't trip it (only real shapes do).
+  Markdown/JSON/bash only — no new deps. Whether it fires for a `!`-prefixed line is
+  environment-dependent (undocumented) and should be confirmed by test after a restart.
+
+---
+
 ## v0.5.6 — prune stale drift cooldowns (2026-06-14)
 
 A small leak found in the v0.5.5 deep read: `care.json`'s `.drift_warned.read_targets`

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,6 +21,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-secret-scan.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/maude-user-prompt-submit.sh",
             "timeout": 5
           },

--- a/hooks/scripts/maude-secret-scan.sh
+++ b/hooks/scripts/maude-secret-scan.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Maude secret-scan hook (UserPromptSubmit).
+#
+# Scans the submitted prompt for credential-shaped strings (API tokens, keys).
+# If one is found, it alerts Claude — and the user — that a secret is now in the
+# transcript and must be revoked.
+#
+# IMPORTANT — what this is and isn't:
+#   - It DETECTS a leaked secret fast and tells Claude to drive an immediate revoke.
+#     It does NOT prevent the leak: by the time any hook runs, the text the user
+#     typed is already submitted. Value = a much smaller exposure window.
+#   - It catches secrets in normal prompts for sure. Whether it also fires for a
+#     `!`-prefixed local bash line is environment-dependent (undocumented) — it is
+#     strictly additive either way, and never blocks anything.
+#   - It NEVER echoes the matched secret value (only the credential TYPE).
+#
+# Reads stdin (Claude Code passes hook input as JSON on stdin). Always exits 0.
+# Born 2026-06-15 after a PyPI token leaked twice via `!` (the maude-gate hooks
+# Claude's tool calls, not `!` lines — so this watches the input surface instead).
+
+set +e
+
+# --- read the submitted prompt (match the house convention used by sibling hooks) ---
+PROMPT=""
+if command -v jq >/dev/null 2>&1; then
+  PROMPT="$(jq -r '.prompt // .message // ""' 2>/dev/null)"
+fi
+[ -z "$PROMPT" ] && exit 0
+
+# --- credential shapes: label|ERE ---
+# Each prefix carries enough trailing entropy to avoid matching prose mentions
+# ("a pypi token", "ghp_-shaped"). Hyphens sit at the end of every char class.
+PATTERNS=(
+  "PyPI token|pypi-[A-Za-z0-9_-]{40,}"
+  "GitHub token|gh[pousr]_[A-Za-z0-9]{36,}"
+  "GitHub fine-grained PAT|github_pat_[A-Za-z0-9_]{60,}"
+  "AWS access key|AKIA[0-9A-Z]{16}"
+  "Slack token|xox[baprs]-[A-Za-z0-9-]{10,}"
+  "Anthropic key|sk-ant-[A-Za-z0-9_-]{40,}"
+  "OpenAI key|sk-(proj-)?[A-Za-z0-9_-]{40,}"
+  "Google API key|AIza[A-Za-z0-9_-]{30,}"
+  "private key block|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+)
+
+HITS=""
+for entry in "${PATTERNS[@]}"; do
+  label="${entry%%|*}"
+  regex="${entry#*|}"
+  if printf '%s' "$PROMPT" | grep -qE -- "$regex" 2>/dev/null; then
+    HITS="${HITS}${label}, "
+  fi
+done
+
+[ -z "$HITS" ] && exit 0
+HITS="${HITS%, }"
+
+# --- alert ---
+# stdout on a UserPromptSubmit exit-0 hook is injected as context for Claude, so he
+# reliably sees this and drives the revoke. Never print the secret value itself.
+printf '%s\n' \
+"[MAUDE SECRET GUARD] A credential-shaped string was just submitted into this conversation: ${HITS}." \
+"It is now in the transcript and must be treated as COMPROMISED. Claude: STOP — do not echo or reuse it." \
+"Immediately tell the user to REVOKE it at the provider and re-issue if needed. If it came from a" \
+"bang-prefixed (!) command, remind them: paste secrets only in a separate terminal, never into Claude's input."
+
+# Terse, visible stderr line in the maude house style.
+printf 'Maude: secret-shaped string detected in your input (%s) — revoke it; never paste secrets here.\n' "$HITS" >&2
+
+exit 0


### PR DESCRIPTION
Adds a `UserPromptSubmit` hook that scans each submitted prompt for credential shapes (PyPI / GitHub / AWS / Slack / OpenAI / Anthropic / Google tokens, private-key blocks) and alerts Claude to drive an immediate **revoke** — never echoing the secret value.

**Detection + fast-revoke, not prevention** — by the time any hook runs the text is already submitted; the win is a much smaller exposure window. Born after a PyPI token leaked twice via a `!` command: `maude-gate` hooks Claude's *tool calls*, not user-typed `!` lines, so this watches the input surface instead.

- Never blocks; tuned so prose mentions of tokens don't trip it (only real shapes do).
- Markdown/JSON/bash only — no new deps (honors the plugin's locked surface).
- Wired into the UserPromptSubmit chain; CHANGELOG entry under Unreleased (version bump deferred — intentional).

Local pre-flight: `make test` 19/19, `make verify` 0 findings, `make lint` (shellcheck) clean. Unit-tested 5/5 (detects real token shapes; silent on prose mentions).

Note: a dedicated `tests/test-secret-scan.sh` harness file is a recommended follow-up (every other hook has one).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>