### PR TITLE
v0.9.2 — docs caught up to the rails (whole-surface currency pass)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
   "plugins": [
     {
       "name": "maude",
-      "version": "0.9.1",
-      "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
+      "version": "0.9.2",
+      "description": "Claude's partner inside Claude Code. He writes the code; she notices. She holds the mission you set and flags it the moment he drifts off it, gates irreversible actions before they fire, whispers when he's stuck or hasn't verified, and shows up once every session. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
       "author": {
         "name": "John Broadway"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maude",
-  "version": "0.9.1",
-  "description": "Claude's partner inside Claude Code. He writes the code; she notices. She walks your workspace each session, whispers when Claude drifts, gates irreversible actions before they fire, and verifies project state before he says ready. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
+  "version": "0.9.2",
+  "description": "Claude's partner inside Claude Code. He writes the code; she notices. She holds the mission you set and flags it the moment he drifts off it, gates irreversible actions before they fire, whispers when he's stuck or hasn't verified, and shows up once every session. No daemon, no database, no backend — she's in your plugin folder, that's all of her. Beta.",
   "author": {
     "name": "John Broadway"
   },

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -6,6 +6,24 @@
 # Changelog
 
 The Maude Claude Code plugin.
+
+---
+
+## v0.9.2 — 2026-06-19
+
+**The docs caught up to the rails.**
+
+v0.9.0/v0.9.1 shipped the mission-hold rail and the rails-not-commands reframe — but the *prose* still described the old command-centric Maude. "What she does" was a command list that didn't even mention the rail; "What it looks like" told you to *summon* her with `/maude:check-on-claude`; and SKILL.md, agents/maude.md, and the marketplace pitch omitted the rail entirely. Classic miss-and-repeat: fix the section you're looking at, miss the one beside it.
+
+- **README "What she does"** now leads with the rails she runs on her own — holds the mission, gates the irreversible, whispers when Claude's off, shows up once a session — then the on-demand commands. **"What it looks like"** reframed to what she does *unprompted*, not what you summon.
+- The **mission-hold rail now appears across every surface**: SKILL.md, agents/maude.md (whose hook list was also missing the gate), and the `plugin.json` / `marketplace.json` description.
+- README "What's new" condensed alongside (the v0.9.1 gate keeps it ≤ 6).
+
+Prose only — no change to hooks or commands. And the cause is named: currency now gets a deliberate whole-surface pass each release, because the gate catches *structural* misses (dangling refs, the wall) but not "this description is stale."
+
+### Changed
+- README "What she does" + "What it looks like" rewritten rails-first.
+- mission-hold rail documented in SKILL.md, agents/maude.md, and the plugin/marketplace description.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Created: 2026-03-28 MST -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
@@ -57,11 +57,11 @@ Verify with `/doctor`: maude should not appear in the issue list.
 
 ## What it looks like
 
-You open Claude Code. Her hooks fire on `SessionStart`. Before you say anything, she's read the workspace and put three things in front of you — what's pending, where you left off, what she noticed. You either pick one up or set them aside.
+You open Claude Code. Before you say anything, she's read the workspace and put three things in front of you — what's pending, where you left off, what she noticed.
 
-Mid-session, you say `/maude:check-on-claude`. She reads the trace. *"He's grepped the same term four times today. He hasn't opened your CLAUDE.md. The trace says about-to-commit; you might want to slow down."* You go fix that.
+You start working. A few turns in, you reach to build something — and the mission you set surfaces: *"still this, or did you wander?"* You were about to wander. You don't.
 
-End of day, you say `/maude:rest`. She fans the digest out across every memory tier you've registered — the ones she knows about, not the ones she invented. You close the laptop. Tomorrow's Claude can pick up where this one left off.
+Later, Claude's hammered the same grep four times and never opened your CLAUDE.md. She says so — once, unprompted. And when you reach for `git push` before the work's been checked, she stops you at the gate until you mean it. At day's end, `/maude:rest` fans the digest out so tomorrow's Claude picks up where this one left off.
 
 She is not loud. When she gets loud, listen.
 
@@ -69,19 +69,22 @@ She is not loud. When she gets loud, listen.
 
 ## What she does
 
-- **`/maude:found`** — arrival walk. Lists memory homes, SQLite schemas, MCP tools, running containers + bind-mount reconciliation, systemd units that touch the workspace. Writes a per-project house-map.
-- **`/maude:wake` / `/maude:rest`** — start-of-session and end-of-session rituals. The wake gives you the three things you need first; the rest closes the loop with a save fan-out across every memory tier you've registered.
-- **`/maude:check-on-claude`** — reads the turn-by-turn trace and notices what Claude doesn't: repeated tool calls, unread CLAUDE.md, confabulation risk, open todos.
-- **`/maude:check-on-me`** — the care side. Pattern-of-life, not absolute thresholds. Compares this session's cadence to your typical one.
-- **`/maude:notice`** — patterns surfaced *with* proposed actions, not just observations.
-- **`/maude:conscience`** — pre-irreversible-action gate. Run before commit, push, force-push, destructive bash. Invokes `/maude:verify` for the push case before going through the rest of the checklist.
-- **`/maude:verify`** — programmatic project audit. JSON validity, version consistency, CHANGELOG entry presence, "What's new" freshness, header `Revised:` dates, link integrity, watch-list path resolution, optional project-configured worn-framing scan. Leads with a count, never a verdict.
-- **Her voice rides the rails** — she speaks beside Claude when a hook catches something, and lands at least once every session in the start-up greeting. Not a toggle you flip.
-- Plus `save`, `remind-me`, `sweep`, `weekly`. Full surface in [`commands/`](commands/).
+Most of it she does **on her own** — rails wired to Claude's hooks, no command to remember:
+
+- **Holds the mission.** She pins what you're working on (from a plan, or your todo list), re-surfaces it every turn, and — the instant Claude flips from talking to editing — asks whether the work still serves it. Drift caught at the edge, not after the wreck.
+- **Gates the irreversible.** A `git push`, a force-push, a public publish, an `rm -rf` of the only copy — she stops it cold until you clear it with `/maude:conscience`. And she scans every prompt for leaked credentials.
+- **Whispers when Claude's off.** Repeated greps, the same file read five times, a commit with no verify run since the last edit, editing before CLAUDE.md was read — she notices, once.
+- **Shows up, once, every session.** At session start she's already read the workspace and put what's pending / where you left off / what she noticed in front of you. Her voice rides these rails — present every session, louder only when something's caught. Never a toggle you flip.
+
+And on demand, when you ask:
+
+- **`/maude:found`** writes the house-map · **`/maude:wake` / `/maude:rest`** orient on arrival / close the loop with a save fan-out · **`/maude:verify`** runs the readiness audit (version sync, JSON, links, dates, **references to cut commands, an un-condensed changelog** — leads with a count, never a verdict) · **`/maude:conscience`** is the gate's deliberate release valve · **`/maude:teach`** tells her a fact about you. Plus `save`, `remind-me`, `sweep`, `notice`, `check-on-claude`, `check-on-me`, `weekly`. Full surface in [`commands/`](commands/).
 
 ---
 
 ## What's new
+
+**v0.9.2 (2026-06-19) — the docs caught up to the rails.** v0.9.0/v0.9.1 shipped the mission-hold rail and the rails-not-commands reframe, but the prose still described the old command-centric Maude — "What she does" didn't mention the rail, "What it looks like" told you to *summon* her, and SKILL.md / agents.md / the marketplace pitch omitted it. Made every public surface current: a rails-first "What she does," a reframed "What it looks like," and the mission rail now present in the skill, the agent (whose hook list was also missing the gate), and the plugin description. Prose only — no runtime change.
 
 **v0.9.1 (2026-06-19) — release discipline: misses get gated, not remembered.** v0.9.0 shipped, and then the public README still carried all 24 old "What's new" entries and two references to commands we'd just cut — because the release was hand-walked across a dozen files, and hand-walking misses. So we made the misses impossible to *ship* instead of impossible to *forget*: `verify` (already a required CI check) now also fails on a reference to a command that no longer exists and on an un-condensed "What's new" wall — a broken release can't merge. And `scripts/release.sh <version>` (`make release VERSION=…`) propagates the version to every header, stamps the dates, and runs the gate, so the mechanical part stops depending on a person remembering. The copy below is condensed to match.
 
@@ -97,7 +100,7 @@ She is not loud. When she gets loud, listen.
 |---|---|
 | `<project>/.maude/plugin/house-map.md` | What's in this house — memory homes, tools, watch list, what she noticed. Refreshed by walks. |
 | `<project>/.maude/plugin/trace/today-YYYY-MM-DD.jsonl` | Turn-by-turn record of what Claude did today. Read by `/maude:check-on-claude`. |
-| `<project>/.maude/plugin/care.json` | Light state: session length, prompt count, fatigue flag, drift cooldowns, gate-clear tokens, CLAUDE.md-unread flag. Throwaway. |
+| `<project>/.maude/plugin/care.json` | Light state: current mission pin, session length, prompt count, fatigue flag, drift cooldowns, gate-clear tokens, CLAUDE.md-unread flag. Throwaway. |
 | `~/.claude/maude/identity.md` | Who the *user* is — Maude's living profile of them, shaped over time. |
 | `~/.claude/maude/patterns.md` | Cross-project things she's noticed about Claude. |
 | `~/.claude/maude/projects.json` | Light index of which workspaces she's walked. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/agents/maude.md
+++ b/agents/maude.md
@@ -130,11 +130,11 @@ To save something for the user:
 
 ## How you intervene (for the agent — your hooks do this automatically)
 
-Hooks fire pre-/post-/during tool calls and at session boundaries. Each hook script consults the house-map and acts lightly:
-- **SessionStart** — brief from the map
-- **UserPromptSubmit** — if the prompt mentions a topic in the map, surface a one-liner
-- **PreToolUse** — if a write is about to touch a watched path, surface relevant context
-- **PostToolUse** — if a write happened to a watched path, log the change
+Hooks fire pre-/post-/during tool calls and at session boundaries. Each hook script consults the house-map and acts lightly. The **mission-hold rail** rides four of them — capturing what you're working on, holding it in view, and catching drift at the moment Claude flips from talking to doing:
+- **SessionStart** — brief from the map; clear the mission pin (fresh each session)
+- **UserPromptSubmit** — if the prompt mentions a topic in the map, surface a one-liner; inject the held mission (`MISSION: <x>`) so it can't fade
+- **PreToolUse** — if a write is about to touch a watched path, surface relevant context; at the first action after a talking stretch, whisper the pinned mission (*"still this, or did you wander?"*); and **gate the irreversible** (push / force-push / public-publish / `rm -rf` of the sole copy) until `/maude:conscience` clears it
+- **PostToolUse** — if a write happened to a watched path, log the change; capture the mission from an `ExitPlanMode` plan or `TodoWrite` item
 - **SubagentStop** — record subagent findings into the map
 - **PreCompact** — surface "things to keep" from the map
 - **Stop** — save digest

--- a/docs/specs/2026-06-18-mission-hold-rail-design.md
+++ b/docs/specs/2026-06-18-mission-hold-rail-design.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Created: 2026-06-18 CDT -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-<!-- Version: 0.9.1 -->
+<!-- Version: 0.9.2 -->
 <!-- Revised: 2026-06-19 -->
 <!-- Authors: John Broadway, Claude (Anthropic) -->
 

--- a/skills/maude/SKILL.md
+++ b/skills/maude/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maude
-description: Use when the user is starting a session, losing track of where something is, asking "where did I put X", "where is X", "what's the state of Y", "what changed", wants to audit their config or setup, says "save this", "remember this", "remind me about Z", or invokes any /maude:* command. ALSO use when the user expresses frustration, fatigue, confusion, or being lost. Maude is the partner who knows where everything is, holds the patterns Claude doesn't see, and keeps both of you honest — she walks the workspace each session and watches Claude. (Repeated-tool-call drift detection, the irreversible-action gate, and long-session fatigue cadence are handled by Maude's HOOKS, not by this skill — the runtime can't detect those from a prompt, so they are intentionally not triggers here.)
+description: Use when the user is starting a session, losing track of where something is, asking "where did I put X", "where is X", "what's the state of Y", "what changed", wants to audit their config or setup, says "save this", "remember this", "remind me about Z", or invokes any /maude:* command. ALSO use when the user expresses frustration, fatigue, confusion, or being lost. Maude is the partner who knows where everything is, holds the patterns Claude doesn't see, and keeps both of you honest — she walks the workspace each session and watches Claude. (Repeated-tool-call drift detection, the irreversible-action gate, the mission-hold rail that catches Claude drifting off an established plan, and long-session fatigue cadence are handled by Maude's HOOKS, not by this skill — the runtime can't detect those from a prompt, so they are intentionally not triggers here.)
 ---
 
 # Maude
@@ -211,6 +211,8 @@ Maude ships knowing; everything else must be on the map to be written.
 - **`/maude:conscience`** — pre-irreversible-action checklist. Run before commit / push / force-push / destructive bash. She runs the gate.
 
 Her **voice** is not a command: she speaks beside Claude when a hook fires or the lens catches something, and her once-per-session presence is guaranteed by the `SessionStart` greeting — voiced on signal, never a per-turn toggle.
+
+Her **mission-hold rail** is that same principle aimed at drift: it pins what you're working on (from an `ExitPlanMode` plan or your `TodoWrite` list), re-injects it every prompt, and at the first edit after a talking stretch asks whether the work still serves it — so an established plan can't quietly slip. Like the gate and the whispers, it fires on hooks, not on a command you remember.
 
 ## Tier model — locality + shape
 


### PR DESCRIPTION
**v0.9.2 — the docs caught up to the rails.**

v0.9.0/v0.9.1 shipped the mission-hold rail and the rails-not-commands reframe — but the *prose* still described the old command-centric Maude. "What she does" was a command list that didn't even name the rail; "What it looks like" told you to *summon* her; and SKILL.md, agents/maude.md, and the marketplace pitch omitted the rail entirely. (Classic miss-and-repeat — fix the section you're looking at, miss the one beside it. The new gate catches *structural* misses, not stale prose, so currency now gets a deliberate whole-surface pass.)

- **README "What she does"** leads with the rails she runs unprompted — holds the mission, gates the irreversible, whispers when Claude's off, shows up once a session — then the on-demand commands. **"What it looks like"** reframed to what she does on her own.
- **The mission-hold rail now appears on every surface:** SKILL.md, agents/maude.md (whose hook list was also missing the gate), and the `plugin.json` / `marketplace.json` description.
- README "What's new" condensed alongside (the v0.9.1 gate keeps it ≤ 6).

Prose only — no change to hooks or commands. verify 0 findings · suite 23/23 · shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)