### PR TITLE
ci: stop Dependabot version-PRs (keep alerts; bumps by hand)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # A bash/markdown plugin has no Python/npm/Go dependency manifests — the only
-  # versioned dependencies are the GitHub Actions pinned in .github/workflows.
-  # Keep those current (and let Dependabot bump any SHA-pins) so CI rides supported actions.
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Removes the github-actions version-update config so Dependabot stops opening automated version-bump PRs (e.g. #27) that add bot-authored commits. Dependabot **alerts** are now enabled at the repo level, so vulnerable deps are still surfaced; bumps get applied by hand under the project's own identity. Security auto-PRs remain off.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>