### PR TITLE
fix(privacy): state the loopback probes — precision over rounding

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,11 +5,13 @@
 
 # Privacy Policy — Maude for Claude
 
-The short version: **everything stays in your house.** Maude makes zero network
-calls, sends zero telemetry, and has zero external dependencies. There is no
-server, no account, no analytics, and nothing that phones home. This document
-exists so you don't have to take that on faith — every claim below is
-verifiable in this repository's source.
+The short version: **everything stays in your house.** Maude contacts no
+remote host, sends zero telemetry, and has zero external dependencies. There
+is no server, no account, no analytics, and nothing that phones home. This
+document exists so you don't have to take that on faith — every claim below
+is verifiable in this repository's source, and this policy was corrected once
+(2026-07-17) when an independent review found its first draft overstated;
+the diff is in the history.
 
 ## What Maude stores, and where
 
@@ -27,14 +29,23 @@ All of it on your machine, all of it yours:
   your markdown remains the only canon.
 
 Deleting `<project>/.maude/` and `~/.claude/maude/` removes everything Maude
-has ever recorded. There is no copy anywhere else.
+has ever recorded. There is no copy anywhere else. (One opt-in exception,
+off by default: the `MAUDE_REROLL=on` chore moves your own aging
+`.remember/today-*.md` notes into `.remember/archive/` — your files, moved
+not copied, inside your project.)
 
 ## What Maude transmits
 
-Nothing. No HTTP requests, no DNS lookups, no update checks, no crash
-reports. The plugin surface is bash and python3-stdlib scripts operating on
-local files. (CI enforces this posture: the codebase ships with no network
-client and no third-party dependency to smuggle one in.)
+Nothing to any remote host. No requests to any server, no DNS lookups, no
+update checks, no crash reports. Stated precisely rather than rounded: at
+session start she probes a few **loopback-only** ports (`127.0.0.1` —
+redis/qdrant/neo4j-shaped local dev services) to detect what's running in
+your own house; no name resolution, no payload, nothing beyond your machine
+(`hooks/scripts/maude-probe-tier1.sh` — read it). Beyond that, the plugin
+surface is bash and python3-stdlib scripts operating on local files. There
+is no dedicated CI gate asserting "no network client" — the claim is
+verifiable by inspection: no HTTP library is imported anywhere and the repo
+carries no dependency manifest to smuggle one in.
 
 ## Model calls
 

--- a/hooks/scripts/_maude-common.sh
+++ b/hooks/scripts/_maude-common.sh
@@ -563,7 +563,10 @@ maude_tier1_up() {
 }
 
 # Returns 0 if a network endpoint at $1 (URL or host:port) is reachable within $2 seconds (default 2).
-# Used by /maude:found probes only — not by hooks.
+# CALLED BY A HOOK: maude-probe-tier1.sh runs this at every SessionStart against
+# hardcoded 127.0.0.1 ports (loopback only — no DNS, no payload, nothing leaves
+# the box). PRIVACY.md discloses this; keep the two in sync. (An earlier version
+# of this comment claimed "not by hooks" — that lie let the privacy policy drift.)
 maude_tier2_reachable() {
   local target="$1" timeout="${2:-2}"
   case "$target" in


### PR DESCRIPTION
**Independent review, documented per PUBLISHING.md §4 (the second-lens rule):** this diff implements the findings of the adversarial retro-review of PRIVACY.md (run 2026-07-17, full claims-vs-code verification). Its verdict: the lead claim 'zero network calls' was FALSE as written — `maude-probe-tier1.sh` opens loopback-only sockets (curl/nc against hardcoded 127.0.0.1 ports, no DNS, no payload) at every SessionStart; and the 'CI enforces this posture' parenthetical described a check that does not exist. Three claims verified exact (metadata-only trace, the two model calls, zero deps); one minor gap (opt-in re-roll archive move) now disclosed.

The fix: precision over rounding. The policy now states the probes plainly, replaces the false CI claim with the honest verifiable-by-inspection one, and the code comment that said 'not by hooks' — the lie that let the policy drift — is corrected and pointed at PRIVACY.md to keep the pair in sync.

A privacy policy that overstates is worse than none. This one no longer does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)