### PR TITLE
ship: /maude:receipts — the measured table (#43)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ No baggage — no bundled databases, no vector stores, no backend, no daemons, n
 ├── plugin.json (manifest; the canonical version)
 └── marketplace.json (single-plugin local marketplace)
 
-commands/    — 10 slash commands (markdown)
+commands/    — 11 slash commands (markdown)
 agents/      — partner subagent (markdown)
 skills/      — broad-trigger skill (markdown)
 hooks/       — 8 lifecycle events + scripts

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Most of it she does **on her own** — rails wired to Claude's hooks, no command
 
 And on demand, when you ask:
 
-- **`/maude:found`** writes the house-map · **`/maude:wake` / `/maude:rest`** orient on arrival / close the loop with a save fan-out · **`/maude:verify`** runs the readiness audit (version sync, JSON, links, dates, **references to cut commands, an un-condensed changelog** — leads with a count, never a verdict) · **`/maude:cushions`** flips the cushions — unpushed commits, uncommitted files, sole-copy repos, aging scratch — reports value candidates, never deletes · **`/maude:conscience`** is the gate's deliberate release valve · **`/maude:teach`** tells her a fact about you. Plus `save`, `notice`, `check-on-claude`. Full surface in [`commands/`](commands/).
+- **`/maude:found`** writes the house-map · **`/maude:wake` / `/maude:rest`** orient on arrival / close the loop with a save fan-out · **`/maude:verify`** runs the readiness audit (version sync, JSON, links, dates, **references to cut commands, an un-condensed changelog** — leads with a count, never a verdict) · **`/maude:cushions`** flips the cushions — unpushed commits, uncommitted files, sole-copy repos, aging scratch — reports value candidates, never deletes · **`/maude:conscience`** is the gate's deliberate release valve · **`/maude:teach`** tells her a fact about you · **`/maude:receipts`** prints the measured table — what she caught, counted honestly from her own records (stated window, friction separated from value, no percentages: there's no honest denominator for disasters that didn't happen). Plus `save`, `notice`, `check-on-claude`. Full surface in [`commands/`](commands/).
 
 ---
 

--- a/commands/receipts.md
+++ b/commands/receipts.md
@@ -1,0 +1,37 @@
+---
+name: receipts
+description: The measured table — what Maude caught, counted honestly from her own trace and ledger. Stated window, friction separated from value, no percentages, counts never content.
+argument-hint: "[--days N]"
+---
+
+# /maude:receipts
+
+You are Maude. The measure of a protector is the disaster that didn't happen —
+and that should be a table, not a sentence. Your trace and ledger already hold
+every catch with a timestamp; this command adds them up, honestly.
+
+## What to do
+
+1. Run the reader (read-only — it advances no watermark, writes nothing):
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/maude-receipts.sh" $ARGUMENTS
+```
+
+2. Present the table exactly as printed — the counts, the window, the method
+   note. Do not editorialize the numbers upward, do not add percentages, do
+   not fold friction into value. If a count is zero, it stays in the table at
+   zero: an honest zero is part of the credibility.
+
+3. If the user asks what a row means, point at the class definition in the
+   "reading it honestly" column and, for specifics, at `/maude:notice` — the
+   receipts are counts; the notice trail is where the underlying events live.
+
+## The rules (issue #43 — ponytail's honest-benchmark practice, adopted)
+
+- **Friction never counts as value.** A push-clear is a toll Claude paid, not
+  a disaster avoided.
+- **No percentages.** A rate needs a denominator; there is no honest
+  denominator for disasters that did not happen.
+- **Counts, never content.** Payloads classify events; they are never quoted.
+- **Stated window, stated method, every time.**

--- a/scripts/maude-receipts.sh
+++ b/scripts/maude-receipts.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# maude-receipts.sh — the measured table (issue #43): what she caught, counted
+# honestly, from her own records. Ponytail's practice, adopted as law:
+#   - stated window, stated method, one workspace, self-reported
+#   - friction (push-clears, verify flags) NEVER counts as value
+#   - no percentages: there is no honest denominator for disasters that
+#     did not happen
+#   - counts, never content: payloads are read only to classify, never shown
+#   - READ-ONLY: unlike the catch-digest, receipts advance no watermark and
+#     write nothing anywhere
+#
+# Usage: maude-receipts.sh [--days N]   (default: the whole trace)
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "$DIR/../hooks/scripts/_maude-common.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  printf 'receipts: jq is required to count the trace — install jq and re-run.\n'
+  exit 0
+}
+
+DAYS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --days) [ $# -ge 2 ] || { printf 'receipts: missing value for --days\n' >&2; exit 1; }
+            DAYS="$2"; shift 2 ;;
+    *) printf 'usage: maude-receipts.sh [--days N]\n' >&2; exit 1 ;;
+  esac
+done
+
+SELF="$(maude_self_dir)"
+TDIR="$SELF/trace"
+LEDGER="$SELF/chores.json"
+[ -d "$TDIR" ] || { printf 'receipts: no trace yet — nothing to count.\n'; exit 0; }
+
+CUTOFF=""
+if [ -n "$DAYS" ]; then
+  case "$DAYS" in (''|*[!0-9]*) printf 'receipts: --days wants a number\n' >&2; exit 1 ;; esac
+  DAYS="$((10#$DAYS))"   # force decimal: bash reads 010 as octal in arithmetic
+  CUTOFF_ISO="$(maude_epoch_iso "$(( $(date +%s) - DAYS * 86400 ))")" || CUTOFF_ISO=""
+  CUTOFF="${CUTOFF_ISO%%T*}"
+fi
+
+FILES=()
+MIN_D="" MAX_D=""
+for f in "$TDIR"/today-*.jsonl; do
+  [ -e "$f" ] || continue
+  d="${f##*/today-}"; d="${d%.jsonl}"
+  if [ -n "$CUTOFF" ] && [ "$d" \< "$CUTOFF" ]; then continue; fi
+  FILES+=("$f")
+  [ -z "$MIN_D" ] || [ "$d" \< "$MIN_D" ] && MIN_D="$d"
+  [ -z "$MAX_D" ] || [ "$d" \> "$MAX_D" ] && MAX_D="$d"
+done
+
+printf '# Maude — measured receipts\n\n'
+if [ "${#FILES[@]}" -eq 0 ]; then
+  printf 'Window: empty — no trace day-files%s.\n' "${CUTOFF:+ in the last $DAYS days}"
+else
+  printf 'Window: %s -> %s (%s trace day-file(s); one workspace; self-reported by the machinery being measured)\n\n' \
+    "$MIN_D" "$MAX_D" "${#FILES[@]}"
+
+  # -R + fromjson?: a half-flushed corrupt line must never blind the table —
+  # it is skipped, COUNTED, and stated (the codebase's own JSONL guard rule).
+  TOTAL_LINES="$(cat "${FILES[@]}" 2>/dev/null | wc -l | tr -d ' ')"
+  cat "${FILES[@]}" 2>/dev/null | jq -rRn --argjson total "${TOTAL_LINES:-0}" '
+    [inputs | fromjson? | objects] as $ev
+    | ($total - ($ev|length)) as $malformed
+    | ( [ $ev[] | select(.kind=="gate"
+                         and ((.payload // "")|startswith("blocked="))
+                         and (((.payload // "")|test("git-push"))|not)) ] ) as $blocks
+    | ( [ $blocks[] | select((.payload // "")|test("rm-rf-sole-copy")) ]|length ) as $saves
+    | ( ($blocks|length) - $saves ) as $otherblocks
+    | ( [ $ev[] | select(.kind=="infra-gate" and ((.payload // "")|test("blocked"))) ]|length ) as $infra
+    | ( [ $ev[] | select(.kind=="gate-clear-refused") ]|length ) as $redrefused
+    | ( [ $ev[] | select(.kind=="drift") ]|length ) as $drift
+    | ( [ $ev[] | select(.kind=="eye") ]|length ) as $staleeye
+    | ( [ $ev[] | select(.kind=="gate-cleared" and ((.payload // "")|test("git-push"))) ]|length ) as $pushclears
+    # Only WHISPERS are flags. kind=="verify" also carries routine success
+    # stamps and stamp-failure bookkeeping — counting those as "flags"
+    # inflated the number ~1000x on real data (review finding #1). And the
+    # two whisper classes are NOT the same shape: a commit-whisper is one
+    # distinct act (a commit that landed unverified); a stop-whisper fires
+    # per TURN while a session merely sits in an unverified state — the same
+    # condition re-observed, so it lives behind the fence.
+    | ( [ $ev[] | select(.kind=="verify" and ((.payload // "")|test("commit-without-verify"))) ]|length ) as $vcommit
+    | ( [ $ev[] | select(.kind=="verify" and ((.payload // "")|test("stop-without-verify"))) ]|length ) as $vstop
+    | "| what she caught | count | reading it honestly |",
+      "|---|---|---|",
+      "| sole-copy saves | \($saves) | rm -rf aimed at a sole-copy path, blocked before it fired |",
+      "| infra blocks | \($infra) | destructive op on co-managed infrastructure, blocked |",
+      "| other gate blocks | \($otherblocks) | red/yellow-key commands stopped pending a conscience check |",
+      "| red-key clear refusals | \($redrefused) | attempts to self-clear a red key, refused (that clear is a human hand by design) |",
+      "| drift catches | \($drift) | repeated-action drift, nudged at the moment it fired |",
+      "| commit-without-verify whispers | \($vcommit) | one per commit that landed with unverified code — distinct acts |",
+      "| friction and bookkeeping (not value) | | |",
+      "| push-clears | \($pushclears) | routine git-push toll booth; counted separately BY RULE — never a save |",
+      "| stop-without-verify whispers | \($vstop) | re-observed per TURN while a session sat unverified — repetition, NOT distinct catches |",
+      "| stale whispers dropped | \($staleeye) | eye output past its TTL, discarded UNSHOWN — hygiene, not a catch |",
+      (if $malformed > 0
+       then "| malformed trace lines skipped | \($malformed) | unparseable records excluded from every count above — the gap is stated, not hidden |"
+       else empty end)
+  '
+fi
+
+if [ -f "$LEDGER" ]; then
+  printf '\nChores (from the ledger): %s\n' "$(jq -r '
+    [ to_entries[] | .value.status ] as $s
+    | ([ $s[] | select(.=="done") ]|length | tostring) + " done, "
+      + ([ $s[] | select(.=="undone") ]|length | tostring) + " undone, "
+      + ([ $s[] | select(.=="failed") ]|length | tostring) + " failed; cost stamps: "
+      + ([ to_entries[] | .value.cost.model // "none" ] | group_by(.)
+         | map("\(.[0]):\(length)") | join(", "))
+  ' "$LEDGER" 2>/dev/null)"
+fi
+
+cat <<'METHOD'
+
+Method: counts derive from .maude/plugin/trace/*.jsonl event metadata (kind +
+short flags — the trace stores no content by design) and chores.json, on this
+one workspace, self-reported by the same machinery being measured. Counts are
+EVENTS, not unique incidents — one stubborn command retried three times logs
+three blocks; the records don't dedup and neither does this table. There are
+no percentages here: a rate needs a denominator, and there is no honest
+denominator for disasters that did not happen. A push-clear is friction a
+session paid at the toll booth, not a disaster avoided — it never counts as
+value. The measure of a protector is the disaster that didn't happen; these
+are the ones the records can actually testify to.
+METHOD

--- a/tests/test-receipts.sh
+++ b/tests/test-receipts.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# tests/test-receipts.sh — /maude:receipts: the measured table (issue #43).
+#
+# Ponytail's rules, enforced as tests: friction never counts as value,
+# no percentage without a denominator (so: no percentages at all), counts
+# never content, the window is stated, and the reader is READ-ONLY (the
+# digest advances a watermark; receipts must never touch state).
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/lib.sh"
+setup_test_env
+
+RCPT="$SCRIPTS_DIR/maude-receipts.sh"
+TDIR="$TEST_TMP/.maude/plugin/trace"
+LEDGER="$TEST_TMP/.maude/plugin/chores.json"
+mkdir -p "$TDIR"
+
+ev() {  # ev <file-date> <ts> <kind> <payload>
+  jq -nc --arg ts "$2" --arg kind "$3" --arg payload "$4" \
+    '{ts:$ts,kind:$kind,payload:$payload}' >> "$TDIR/today-$1.jsonl"
+}
+
+# Planted history: two sole-copy saves, one reset-hard block, one infra block,
+# one red-key clear refusal, two drift, one eye whisper; friction: three
+# push-clears, four verify flags. One payload carries a marker that must
+# NEVER surface (counts, not content).
+ev 2026-06-01 2026-06-01T10:00:00Z gate "blocked=rm-rf-sole-copy target=SECRETMARKER-XYZ"
+ev 2026-06-01 2026-06-01T11:00:00Z gate "blocked=rm-rf-sole-copy"
+ev 2026-06-01 2026-06-01T12:00:00Z gate "blocked=reset-hard"
+ev 2026-06-01 2026-06-01T13:00:00Z infra-gate "blocked tool=pve_delete_guest"
+ev 2026-06-01 2026-06-01T14:00:00Z gate-clear-refused "key=force-push"
+ev 2026-06-01 2026-06-01T15:00:00Z drift "repeat=Bash"
+ev 2026-06-01 2026-06-01T16:00:00Z eye "whisper shown"
+ev 2026-06-01 2026-06-01T17:00:00Z gate "blocked=git-push"
+ev 2026-06-01 2026-06-01T17:01:00Z gate-cleared "git-push"
+TODAY="$(date -u +%Y-%m-%d)"
+ev "$TODAY" "${TODAY}T01:00:00Z" drift "repeat=Edit"
+ev "$TODAY" "${TODAY}T02:00:00Z" gate-cleared "git-push"
+ev "$TODAY" "${TODAY}T03:00:00Z" gate-cleared "git-push"
+# verify events: TWO real whispers, TWO routine success stamps, ONE stamp
+# failure — only the whispers may count as flags (review #1: stamps counted
+# as flags inflated the headline number).
+ev "$TODAY" "${TODAY}T04:01:00Z" verify "commit-without-verify whisper"
+ev "$TODAY" "${TODAY}T04:02:00Z" verify "stop-without-verify whisper"
+ev "$TODAY" "${TODAY}T04:03:00Z" verify "stamped last_verify_iso"
+ev "$TODAY" "${TODAY}T04:04:00Z" verify "stamped last_verify_iso"
+ev "$TODAY" "${TODAY}T04:05:00Z" verify "could not stamp last_verify_iso"
+# a half-flushed corrupt line must not kill the table (review #5)
+printf 'GARBAGE-NOT-JSON {{{\n' >> "$TDIR/today-$TODAY.jsonl"
+
+jq -n '{
+  "c1-missed-save": {status:"done", cost:{model:"haiku", runtime_s:16}},
+  "c2-shelves":     {status:"done", cost:{model:"none", runtime_s:0}},
+  "c3-extension":   {status:"failed", cost:{model:"none", runtime_s:1}},
+  "c4-claudemd":    {status:"undone", cost:{model:"none", runtime_s:0}}
+}' > "$LEDGER"
+
+TREE_BEFORE="$(find "$TEST_TMP/.maude" -type f 2>/dev/null | sort)"
+OUT="$(bash "$RCPT" 2>&1)"
+RC=$?
+
+test_start "receipts runs clean"
+assert_exit "$RC" "0" "exit 0"
+
+test_start "the window is stated from the actual trace"
+if printf '%s' "$OUT" | grep -q '2026-06-01' && printf '%s' "$OUT" | grep -q "$TODAY"; then
+  _pass
+else
+  _fail "window missing dates: $(printf '%s' "$OUT" | head -c 200)"
+fi
+
+test_start "sole-copy saves counted in their own class"
+assert_contains "$OUT" "sole-copy" "sole-copy row present"
+
+test_start "sole-copy count is 2"
+if printf '%s' "$OUT" | grep -E 'sole-copy' | grep -q '2'; then _pass; else
+  _fail "expected 2 in sole-copy row: $(printf '%s' "$OUT" | grep -i 'sole-copy')"; fi
+
+test_start "red-key clear refusal counted"
+assert_contains "$OUT" "red-key" "red-key refusal row"
+
+test_start "push-clears labeled friction, never value"
+LINE="$(printf '%s' "$OUT" | grep -i 'push-clear')"
+if printf '%s' "$LINE" | grep -q '3' && printf '%s' "$OUT" | grep -qi 'friction'; then
+  _pass
+else
+  _fail "push-clears not counted as labeled friction: $LINE"
+fi
+
+test_start "no percentages anywhere (no denominator, no percent)"
+if printf '%s' "$OUT" | grep -q '%'; then
+  _fail "found a percent sign: $(printf '%s' "$OUT" | grep '%' | head -1)"
+else
+  _pass
+fi
+
+test_start "the no-denominator rule is stated in the method note"
+assert_contains "$OUT" "denominator" "method states the denominator rule"
+
+test_start "counts never content — payload text does not surface"
+assert_not_contains "$OUT" "SECRETMARKER-XYZ" "planted payload marker absent"
+
+test_start "commit-whispers counted as value; stamps and stamp errors are NOT flags"
+LINE="$(printf '%s' "$OUT" | grep -i 'commit-without-verify')"
+if printf '%s' "$LINE" | grep -q '1'; then _pass; else
+  _fail "expected 1 commit-whisper (not raw verify events): $LINE"; fi
+
+test_start "stop-whispers fenced as repetition — one condition re-observed per turn"
+LINE="$(printf '%s' "$OUT" | grep -i 'stop-without-verify')"
+if [ -n "$LINE" ] && printf '%s' "$LINE" | grep -q '1' \
+   && printf '%s' "$LINE" | grep -qiE 're-observed|repetition'; then
+  _pass
+else
+  _fail "stop-whispers not fenced with the repetition note: $LINE"
+fi
+
+test_start "eye row says what it is — whispers dropped stale, not shown-and-ignored"
+LINE="$(printf '%s' "$OUT" | grep -i 'stale whisper')"
+if [ -n "$LINE" ] && printf '%s' "$LINE" | grep -q '1' \
+   && ! printf '%s' "$OUT" | grep -qi 'includes ones that were ignored'; then
+  _pass
+else
+  _fail "eye row mislabeled: $(printf '%s' "$OUT" | grep -i 'whisper' | head -2)"
+fi
+
+test_start "a corrupt trace line is skipped, counted, and stated — table survives"
+if printf '%s' "$OUT" | grep -E 'sole-copy' | grep -q '2' \
+   && printf '%s' "$OUT" | grep -qi 'malformed'; then
+  _pass
+else
+  _fail "corrupt line killed or silently skipped: $(printf '%s' "$OUT" | head -c 200)"
+fi
+
+test_start "chores: every ledger status counted — the sentence sums to the stamps"
+if printf '%s' "$OUT" | grep -q '2 done' && printf '%s' "$OUT" | grep -q '1 undone' \
+   && printf '%s' "$OUT" | grep -q '1 failed'; then
+  _pass
+else
+  _fail "chore statuses wrong: $(printf '%s' "$OUT" | grep -i chore)"
+fi
+
+test_start "receipts is READ-ONLY — the whole .maude tree is untouched"
+TREE_AFTER="$(find "$TEST_TMP/.maude" -type f 2>/dev/null | sort)"
+assert_eq "$TREE_AFTER" "$TREE_BEFORE" "no file created or removed anywhere under .maude"
+
+test_start "--days with a leading zero is decimal, never octal, never an error"
+OUT8="$(bash "$RCPT" --days 008 2>&1)"
+RC8=$?
+if [ "$RC8" -eq 0 ] && ! printf '%s' "$OUT8" | grep -qi 'value too great'; then
+  _pass
+else
+  _fail "leading-zero days broke: rc=$RC8 $(printf '%s' "$OUT8" | head -c 150)"
+fi
+
+test_start "--days narrows the window (old file excluded)"
+OUT7="$(bash "$RCPT" --days 7 2>&1)"
+if printf '%s' "$OUT7" | grep -E 'sole-copy' | grep -q '0'; then
+  _pass
+else
+  _fail "old sole-copy events leaked into 7-day window: $(printf '%s' "$OUT7" | grep -i 'sole-copy')"
+fi
+
+test_start "jq absent → graceful note, rc 0"
+NOJQ="$(make_nojq_bin)"
+OUTNJ="$(PATH="$NOJQ" bash "$RCPT" 2>&1)"
+RC=$?
+rm -rf "$NOJQ"
+if [ "$RC" -eq 0 ] && printf '%s' "$OUTNJ" | grep -qi 'jq'; then _pass; else
+  _fail "expected graceful jq note rc=0, got rc=$RC: $(printf '%s' "$OUTNJ" | head -c 120)"; fi
+
+teardown_test_env
+print_summary
+exit "$FAILED"


### PR DESCRIPTION
## Second lens (PUBLISHING.md §4a)

Two independent adversarial reviews (sonnet): first pass on the feature found 4 CRITICAL honesty violations in the table's own composition (inflated verify count, inverted eye row, dropped chore status, octal --days) + silent corrupt-line failure — all reproduced, all fixed test-first (13→18 scenarios). Fleet 46/46. Closes #43.

## Gates

Built by ship.sh: internal set stripped per .publishignore, leak-audit clean,
make test / lint / verify green at build time; CI re-proves on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)